### PR TITLE
Fix issue where dev exceptions would not be formatted correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # WIP/Unreleased
 
+- Fix issue where stdout from a kubetools dev exception would not be formatted properly
+
 # v9.1.1
 - Add ability to define number of retries on readinessProbe
 

--- a/kubetools_client/main.py
+++ b/kubetools_client/main.py
@@ -13,22 +13,6 @@ def run_cli(func):
     try:
         func()
 
-    except KubeError as e:
-        if e.type == 'auth':
-            settings = get_settings()
-
-            logger.warning((
-                'You are not logged into Kubetools!\n'
-                'You need to login to your server, download the config '
-                'from the top right and save it to:\n{0}\n'
-            ).format(settings.filename))
-
-        click.echo('--> {0} {1}'.format(
-            click.style('Kubetools {0} exception:'.format(e.type), 'red', bold=True),
-            e,
-        ))
-        sys.exit(1)
-
     except KubeDevCommandError as e:
         message, stdout = e.args
 
@@ -42,6 +26,22 @@ def run_cli(func):
     except KubeDevError as e:
         click.echo('--> {0} {1}'.format(
             click.style('Kubetools dev exception:', 'red', bold=True),
+            e,
+        ))
+        sys.exit(1)
+
+    except KubeError as e:
+        if e.type == 'auth':
+            settings = get_settings()
+
+            logger.warning((
+                'You are not logged into Kubetools!\n'
+                'You need to login to your server, download the config '
+                'from the top right and save it to:\n{0}\n'
+            ).format(settings.filename))
+
+        click.echo('--> {0} {1}'.format(
+            click.style('Kubetools {0} exception:'.format(e.type), 'red', bold=True),
             e,
         ))
         sys.exit(1)


### PR DESCRIPTION
Because the `except KubeError` was first, and `KubeDevCommandError` and `KubeDevError` are both `KubeError`'s, we were never using those `except` blocks. By moving this later, we use the proper `KubeDevCommandError` handler which correctly formats `stdout` (as it's being passed in raw, rather than through the `__str__` handler for `KubeError`.