### PR TITLE
Remove `docker-compose` requirement as it conflicts with everything.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ if __name__ == '__main__':
         install_requires=(
             'click>=7',
             'docker>=3.7,<4.0',
-            'docker-compose',
             'pyyaml>=3,<4.3',
             'pydash',
             'pyretry',


### PR DESCRIPTION
Also needn't be installed as part of this, normally installed with docker.
The dependencies it specifies are really specific making it totally useless
as a package.

Closes: #26 