### PR TITLE
Make it possible to add environment variables via deploy CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix the test condition for upgrades
 - Add `-f` / `--force` argument to `kubetools restart`
 - Fix issues with listing objects in `kubetools restart`
+- Add `-e KEY=VALUE` flag to inject environment variables when using `kubetools deploy`
 
 
 # v11.1.1

--- a/kubetools/cli/deploy.py
+++ b/kubetools/cli/deploy.py
@@ -57,18 +57,18 @@ def _dry_deploy_loop(build, services, deployments, jobs):
             _dry_deploy_object_loop(object_type, objects)
 
 
-def _validate_annotations(ctx, param, value):
-    annotations = {}
+def _validate_key_value_argument(ctx, param, value):
+    key_values = {}
 
-    for annotation_str in value:
+    for key_value_str in value:
         try:
-            key, value = annotation_str.split('=', 1)
+            key, value = key_value_str.split('=', 1)
         except ValueError:
-            raise click.BadParameter(f'"{annotation_str}" does not match "key=value".')
+            raise click.BadParameter(f'"{key_value_str}" does not match "key=value".')
         else:
-            annotations[key] = value
+            key_values[key] = value
 
-    return annotations
+    return key_values
 
 
 @cli_bootstrap.command(help_priority=0)
@@ -94,9 +94,15 @@ def _validate_annotations(ctx, param, value):
     help='Flag to auto-yes remove confirmation step.',
 )
 @click.option(
-    'annotations', '--annotation',
+    'envvars', '-e', '--envvar',
     multiple=True,
-    callback=_validate_annotations,
+    callback=_validate_key_value_argument,
+    help='Extra environment variables to apply to Kubernetes objects, format: key=value.',
+)
+@click.option(
+    'annotations', '-a', '--annotation',
+    multiple=True,
+    callback=_validate_key_value_argument,
     help='Extra annotations to apply to Kubernetes objects, format: key=value.',
 )
 @click.option(
@@ -123,7 +129,9 @@ def deploy(
     dry,
     replicas,
     default_registry,
-    yes, annotations,
+    yes,
+    envvars,
+    annotations,
     file,
     ignore_git_changes,
     namespace,
@@ -150,6 +158,7 @@ def deploy(
         build, app_dirs,
         replicas=replicas,
         default_registry=default_registry,
+        extra_envvars=envvars,
         extra_annotations=annotations,
         ignore_git_changes=ignore_git_changes,
         custom_config_file=custom_config_file,

--- a/kubetools/deploy/commands/deploy.py
+++ b/kubetools/deploy/commands/deploy.py
@@ -82,6 +82,7 @@ def get_deploy_objects(
     app_dirs,
     replicas=None,
     default_registry=None,
+    extra_envvars=None,
     extra_annotations=None,
     ignore_git_changes=False,
     custom_config_file=False,
@@ -89,6 +90,13 @@ def get_deploy_objects(
     all_services = []
     all_deployments = []
     all_jobs = []
+
+    envvars = {
+        'KUBE_ENV': build.env,
+        'KUBE_NAMESPACE': build.namespace,
+    }
+    if extra_envvars:
+        envvars.update(extra_envvars)
 
     annotations = {
         'kubetools/env': build.env,
@@ -100,11 +108,6 @@ def get_deploy_objects(
     namespace = generate_namespace_config(build.namespace, base_annotations=annotations)
 
     for app_dir in app_dirs:
-        envvars = {
-            'KUBE_ENV': build.env,
-            'KUBE_NAMESPACE': build.namespace,
-        }
-
         if path.exists(path.join(app_dir, '.git')):
             if not _is_git_committed(app_dir) and not ignore_git_changes:
                 raise KubeBuildError(f'{app_dir} contains uncommitted changes, refusing to deploy!')


### PR DESCRIPTION
Adds an `-e KEY=VALUE` multiple argument to `kubetools deploy`.