### PR TITLE
Fix file flag input NoneType error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v11.1.1
+- Fix `-f` / `--file` handling NoneType attribute error (introduced in v11.1)
+
 # v11.1
 - Add `-f`/`--file` argument to specify custom `kubetools.yml` file location for `kubetools deploy` and `kubetools config`
 - Add `--ignore-git-changes` argument to skip git check for uncommitted files for `kubetools deploy`

--- a/kubetools/cli/deploy.py
+++ b/kubetools/cli/deploy.py
@@ -141,7 +141,10 @@ def deploy(
         namespace=namespace,
     )
 
-    custom_config_file = click.format_filename(file)
+    if file:
+        custom_config_file = click.format_filename(file)
+    else:
+        custom_config_file = None
 
     services, deployments, jobs = get_deploy_objects(
         build, app_dirs,


### PR DESCRIPTION
Introduction of the `-f` / `--file` flag in `v11.1` broke the client when the flag was not being used, producing the error `AttributeError: 'NoneType' object has no attribute 'encode'`