### PR TITLE
Delete completed jobs during deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v12.2.0
+
+- Remove Kubernetes jobs after they complete successfully
 
 # v12.1.0
 - Allow to run upgrades and tests on any container using a containerContext. Especially allows containers that use a released image rather than a Dockerfile

--- a/kubetools/cli/deploy.py
+++ b/kubetools/cli/deploy.py
@@ -117,6 +117,12 @@ def _validate_key_value_argument(ctx, param, value):
     default=False,
     help='Flag to ignore un-committed changes in git.',
 )
+@click.option(
+    'delete_completed_jobs', '--delete-jobs/--no-delete-jobs',
+    is_flag=True,
+    default=True,
+    help='Delete jobs after they complete.',
+)
 @click.argument('namespace')
 @click.argument(
     'app_dirs',
@@ -134,6 +140,7 @@ def deploy(
     annotations,
     file,
     ignore_git_changes,
+    delete_completed_jobs,
     namespace,
     app_dirs,
 ):
@@ -190,6 +197,7 @@ def deploy(
         services,
         deployments,
         jobs,
+        delete_completed_jobs=delete_completed_jobs,
     )
 
 

--- a/kubetools/deploy/commands/deploy.py
+++ b/kubetools/deploy/commands/deploy.py
@@ -15,6 +15,7 @@ from kubetools.kubernetes.api import (
     create_job,
     create_namespace,
     create_service,
+    delete_job,
     deployment_exists,
     get_object_name,
     list_deployments,
@@ -201,7 +202,7 @@ def log_deploy_changes(
         log_actions(build, 'UPDATE', 'deployment', update_deployments, name_formatter)
 
 
-def execute_deploy(build, namespace, services, deployments, jobs):
+def execute_deploy(build, namespace, services, deployments, jobs, delete_completed_jobs=True):
     # Split services + deployments into app (main) and dependencies
     depend_services = []
     main_services = []
@@ -283,6 +284,8 @@ def execute_deploy(build, namespace, services, deployments, jobs):
             for job in jobs:
                 build.log_info(f'Create job: {get_object_name(job)}')
                 create_job(build.env, build.namespace, job)
+                if delete_completed_jobs:
+                    delete_job(build.env, build.namespace, job)
 
     if exist_main_deployments:
         with build.stage('Update existing app deployments'):


### PR DESCRIPTION
Adds a CLI flag to `kubetools deploy` to enable/disable this behaviour.

This is a sensible default to avoid leaving lots of empty job objects
lying around on the cluster. Cluster level logging should handle the
tracking of logs rather than leaving the objects lying around.

Closes: #67 