### PR TITLE
Correlate dev jobs with container context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,14 @@ install: 'pip install -e .[dev]'
 script:
   - flake8
   - pytest --cov
+
+deploy:
+  provider: pypi
+  user: __token__
+  # Due to a bug, using the environment variable defined in the UI for the password
+  # https://github.com/travis-ci/travis.rb/issues/687
+  on:
+    branch: master
+    tags: true
+    python: '3.8'
+  skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - '3.6'
   - '3.7'
   - '3.8'
+  - '3.9-dev'
 
 install: 'pip install -e .[dev]'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Unreleased
 
 
+# v12.1.0
+- Allow to run upgrades and tests on any container using a containerContext. Especially allows containers that use a released image rather than a Dockerfile
+
 # v12.0.3
 
 - Ensure docker compose configs are always generated relative to the kubetools config file

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![Build Status](https://travis-ci.com/EDITD/kubetools.svg?branch=master)](https://travis-ci.com/EDITD/kubetools)
+[![Pypi Version](https://img.shields.io/pypi/v/kubetools.svg)](https://pypi.org/project/kubetools/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/kubetools.svg)](https://pypi.org/project/kubetools/)
+
 # Kubetools
 
 Kubetools is a tool and processes for developing and deploying microservices to Kubernetes. Say that:
@@ -81,3 +85,12 @@ Install the package in editable mode, with the dev extras:
 ```sh
 pip install -e .[dev]
 ```
+
+## Releasing
+* Update [CHANGELOG](CHANGELOG.md) to add new version and document it
+* In GitHub, create a new release
+  * Name the release `v<version>` (for example `v1.2.3`)
+  * Title the release with a highlight of the changes
+  * Copy changes in the release from `CHANGELOG.md` into the release description
+ [TravisCI](https://travis-ci.com/EDITD/kubetools) will package the release and publish it to
+ [Pypi](https://pypi.org/project/kubetools/)

--- a/kubetools/dev/backends/docker_compose/__init__.py
+++ b/kubetools/dev/backends/docker_compose/__init__.py
@@ -37,16 +37,16 @@ def http_get(url, timeout):
 
 
 def find_container_for_config(kubetools_config, config):
-    dockerfile = config['build']['dockerfile']
+    container_context = config['containerContext']
     all_containers = get_all_containers(kubetools_config)
 
     for name, container in all_containers:
-        if container.get('build', {}).get('dockerfile') == dockerfile:
+        if container.get('containerContext') == container_context:
             return name
     else:
         raise KubeDevError((
-            'No container found using Dockerfile: {0}'
-        ).format(dockerfile))
+            'No container found using containerContext: {0}'
+        ).format(container_context))
 
 
 def _build_container(kubetools_config, name, dockerfile):

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -51,23 +51,6 @@ def _ensure_image(
     container['image'] = context_name_to_image[context_name]
 
 
-def _should_expose_ports(ports):
-    for port in ports:
-        if port == 80:  # simply HTTP? OK!
-            return True
-
-        if not isinstance(port, dict):
-            continue
-
-        if (
-            port.get('name') == 'http'  # either called http
-            or port.get('targetPort', port.get('port')) == 80  # or on port 80
-        ):
-            return True
-
-    return False
-
-
 def _get_containers_data(containers, context_name_to_image, deployment_name):
     # Setup top level app service mapping all ports from all top level containers
     all_container_ports = []

--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,16 @@ from setuptools import find_packages, setup
 
 
 # Regex matching pattern followed by 3 numerical values separated by '.'
-pattern = re.compile(r'[0-9]+\.[0-9]+\.?[0-9]*\.?[a-z0-9]*')
+pattern = re.compile(r'# v(?P<version>[0-9]+\.[0-9]+(\.[0-9]+(\.[a-z0-9]+)?)?)')
 
 
 def get_version():
     with open('CHANGELOG.md', 'r') as fn:
-        while True:
-            version = pattern.findall(fn.readline())
-            if len(version) > 0:
-                return ''.join(version[0])
+        for line in fn.readlines():
+            match = pattern.fullmatch(line.strip())
+            if match:
+                return ''.join(match.group("version"))
+    raise RuntimeError("No version found in CHANGELOG.md")
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import re
+from os import path
 
 from setuptools import find_packages, setup
 
@@ -16,6 +17,15 @@ def get_version():
     raise RuntimeError("No version found in CHANGELOG.md")
 
 
+base_dir = path.abspath(path.dirname(__file__))
+
+
+def get_readme_content():
+    readme_file = path.join(base_dir, 'README.md')
+    with open(readme_file, 'r') as f:
+        return f.read()
+
+
 if __name__ == '__main__':
     setup(
         version=get_version(),
@@ -24,9 +34,11 @@ if __name__ == '__main__':
             'Kubetools is a tool and processes for developing and deploying '
             'microservices to Kubernetes.'
         ),
-        author='Devs @ EDITED',
-        author_email='nick@edited.com',
+        author='EDITED devs',
+        author_email='dev@edited.com',
         url='http://github.com/EDITD/kubetools',
+        long_description=get_readme_content(),
+        long_description_content_type='text/markdown',
         packages=find_packages(),
         entry_points={
             'console_scripts': (
@@ -36,6 +48,7 @@ if __name__ == '__main__':
                 'ktd=kubetools.dev.__main__:main',
             ),
         },
+        python_requires='>=3.6',
         install_requires=(
             'click>=7,<8',
             'docker>=3,<5',


### PR DESCRIPTION
Previous code used the build/dockerfile to find a container matching matching the
one wanted to run a job. However this is not accurate since:
* a dockerfile could be used by different containers
* a container may not have a dockerfile if it's running of a standard image

Using containerContext is a little more accurate since it describes more
precisely the container than just the dockerfile. Also any container with
a dockerfile will anyway require a containercontext.
