### PR TITLE
Replace `pydash.memoize` with `functools.lru_cache`.

### DIFF
--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -1,7 +1,7 @@
+from functools import lru_cache
+
 import docker
 import requests
-
-from pydash import memoize
 
 from kubetools.dev.process_util import run_process
 from kubetools.exceptions import KubeDevError
@@ -16,7 +16,7 @@ from .config import (
 )
 
 
-@memoize
+@lru_cache(maxsize=1)
 def get_docker_client():
     client = docker.from_env()
 

--- a/kubetools/settings.py
+++ b/kubetools/settings.py
@@ -1,9 +1,8 @@
 from configparser import ConfigParser
+from functools import lru_cache
 from os import access, listdir, path, X_OK
 
 import click
-
-from pydash import memoize
 
 from .log import logger
 
@@ -34,7 +33,7 @@ def get_settings_directory():
     return click.get_app_dir('kubetools', force_posix=True)
 
 
-@memoize
+@lru_cache(maxsize=1)
 def get_settings():
     settings_directory = get_settings_directory()
     settings_file = path.join(settings_directory, 'kubetools.conf')

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ def get_version():
         for line in fn.readlines():
             match = pattern.fullmatch(line.strip())
             if match:
-                return ''.join(match.group("version"))
-    raise RuntimeError("No version found in CHANGELOG.md")
+                return ''.join(match.group('version'))
+    raise RuntimeError('No version found in CHANGELOG.md')
 
 
 base_dir = path.abspath(path.dirname(__file__))
@@ -54,7 +54,6 @@ if __name__ == '__main__':
             'docker>=3,<5',
             'pyyaml>=3,<6',
             'requests>=2,<3',
-            'pydash',
             'pyretry',
             'setuptools',
             'kubernetes',


### PR DESCRIPTION
Removes an unnecessary dependency and some unnecessary caching.