### PR TITLE
Skip pods with no owners when gathering restart objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v12.2.2
+
+- Ignore pods with no owner metadata when restarting a service
+
 # v12.2.1
 
 - Fix call to check if service exists

--- a/kubetools/deploy/commands/restart.py
+++ b/kubetools/deploy/commands/restart.py
@@ -54,7 +54,7 @@ def get_restart_objects(build, app_names=None, force=False):
     deployment_name_to_pods = defaultdict(list)
 
     for pod in pods:
-        if len(pod.metadata.owner_references) == 1:
+        if pod.metadata.owner_references and len(pod.metadata.owner_references) == 1:
             owner = pod.metadata.owner_references[0]
             deployment = replica_set_names_to_deployment.get(owner.name)
             if deployment:


### PR DESCRIPTION
Dont gather pod object if it has no owner. Likely a leftover pod from a job.