### PR TITLE
Translate k8s command/args to compose entrypoint/command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Unreleased
 
+# v13.0.0
+
+- Translate k8s-style `command`/`args` options to docker[-compose]-style `entrypoint`/`command`
+  
+  This is breaking backwards compatibility for any project using `entrypoint`/`command` options in a `dev` section.
+  These need to be renamed resp. `command`/`args` to be picked up. The bright side of this is that these cases
+  will now only require 1 copy of the options when the same values were just repeated under `dev` to get them to
+  work with `ktd` (`docker-compose`)
+  
 # v12.2.2
 
 - Ignore pods with no owner metadata when restarting a service

--- a/kubetools/dev/backends/docker_compose/config.py
+++ b/kubetools/dev/backends/docker_compose/config.py
@@ -121,10 +121,13 @@ def _create_compose_service(kubetools_config, name, config, envvars=None):
         },
     }
 
-    if 'args' in config:
-        config['command'].extend(config.pop('args'))
-
     service.update(config)
+
+    # Translate k8s command/args to docker-compose entrypoint/command
+    if 'command' in service:
+        service['entrypoint'] = service.pop('command')
+    if 'args' in config:
+        service['command'] = service.pop('args')
 
     if 'build' in service and 'context' not in service['build']:
         service['build']['context'] = '.'

--- a/tests/configs/ktd-compose-bug/Dockerfile
+++ b/tests/configs/ktd-compose-bug/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.9-slim
+ENTRYPOINT ["python"]

--- a/tests/configs/ktd-compose-bug/kubetools.yml
+++ b/tests/configs/ktd-compose-bug/kubetools.yml
@@ -1,0 +1,16 @@
+name: reproduce-ktd-bug-with-compose
+
+containerContexts:
+  container-with-entrypoint:
+    build:
+      dockerfile: Dockerfile
+
+
+deployments:
+  demo-app:
+    containers:
+      demo-container:
+        containerContext: container-with-entrypoint
+        args: ["-c", "print('Hello World')"]  # this works in k8s
+        dev:
+          command: ["-c", "print('Hello World')"]  # this works in ktd


### PR DESCRIPTION
## Purpose of PR
Fix bug where local dev with `ktd` wouldn't work if the docker image has an entrypoint and only "args" are passed through the kubetools config.

:warning: This looks like it would break backwards compatibility but in the direction of a simpler `kubetools.yml`