### PR TITLE
Update kubernetes api create job with non-blocking option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v13.1.0
+
+- Update kubernetes api create job with non-blocking option
+
 # v13.0.0
 
 - Translate k8s-style `command`/`args` options to docker[-compose]-style `entrypoint`/`command`

--- a/kubetools/kubernetes/api.py
+++ b/kubetools/kubernetes/api.py
@@ -271,14 +271,15 @@ def delete_job(env, namespace, job):
     _wait_for_no_object(k8s_batch_api, 'read_namespaced_job', namespace, job)
 
 
-def create_job(env, namespace, job):
+def create_job(env, namespace, job, wait_for_completion=True):
     k8s_batch_api = _get_k8s_batch_api(env)
     k8s_job = k8s_batch_api.create_namespaced_job(
         body=job,
         namespace=namespace,
     )
 
-    wait_for_job(env, namespace, k8s_job)
+    if wait_for_completion:
+        wait_for_job(env, namespace, k8s_job)
     return k8s_job
 
 


### PR DESCRIPTION
## Purpose of PR

Currently the create job function waits for job to complete. As part of moving crawlers to jobs in kubernetes cluster we want to be able to kick off long running job and not wait for completion.

I looked at waiting for active field in job being > 1 but this seems to be more related to pod existing than being available and running so not sure it adds much value

Closes #87 