### PR TITLE
Update push command to allow additional tags for image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v13.5.0
+
+- Update push command to allow additional tags for image
+
 # v13.4.1
 
 - Fix regression from 13.0.0 causing upgrades and tests to fail when using an image with an entrypoint, or specifying

--- a/kubetools/cli/push_image.py
+++ b/kubetools/cli/push_image.py
@@ -14,8 +14,13 @@ from kubetools.deploy.image import ensure_docker_images
     '--default-registry',
     help='Default registry for apps that do not specify.',
 )
+@click.option(
+    'additional_tags', '-t', '--tag',
+    multiple=True,
+    help='Extra tags to apply to built image',
+)
 @click.pass_context
-def push(ctx, default_registry):
+def push(ctx, default_registry, additional_tags):
     '''
     Push app images to docker repo
     '''
@@ -36,4 +41,5 @@ def push(ctx, default_registry):
         kubetools_config, build, app_dir,
         commit_hash=commit_hash,
         default_registry=default_registry,
+        additional_tags=additional_tags,
     )


### PR DESCRIPTION
## Purpose of PR

This allows CLI user to pass tags for image that will be pushed as well as the default commit hash based tag.

![image](https://user-images.githubusercontent.com/8049851/125647272-9fb4cabd-9683-44cc-9dc9-aca6bb8f0b3c.png)