### PR TITLE
Fix defaulting of propagation_policy param in k8s api job deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v13.5.1
+
+- Fix defaulting of propagation_policy param in k8s api job deletion
+
 # v13.5.0
 
 - Update push command to allow additional tags for image

--- a/kubetools/kubernetes/api.py
+++ b/kubetools/kubernetes/api.py
@@ -280,11 +280,14 @@ valid_propagation_policies = ["Orphan", "Background", "Foreground"]
 def delete_job(env, namespace, job, propagation_policy=None):
     if propagation_policy and propagation_policy not in valid_propagation_policies:
         raise KubeBuildError(f"Propagation policy must be one of {valid_propagation_policies}")
+    args = {}
+    if propagation_policy:
+        args['propagation_policy'] = propagation_policy
     k8s_batch_api = _get_k8s_batch_api(env)
     k8s_batch_api.delete_namespaced_job(
         name=get_object_name(job),
         namespace=namespace,
-        propagation_policy=propagation_policy,
+        **args,
     )
 
     _wait_for_no_object(k8s_batch_api, 'read_namespaced_job', namespace, job)


### PR DESCRIPTION
## Purpose of PR

The underlying api client looks like it ignores `None` values passed as argument values but we have seen failures with `None` values present in the request made to kubernetes api.

This change updates to not pass value through to client at all unless it is explicitly provided.