### PR TITLE
Update to only build/push docker images relevant to current context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.6.2
+- Only build/push images relevant to relevant container contexts during a deploy
+
 # v13.6.1
 
 - Convert timeout envvar to int


### PR DESCRIPTION
## Purpose of PR

Currently when ensuring images are present in repo during a deploy or push we loop over all container contexts present in the config. As context filters (dev, envs, namespaces etc.) are not applied to container contexts this results in unnecessary images being built/pushed.

This change updates to look only at containers that are present in config after filtering has been applied. Container contexts are then looked up from there.