### PR TITLE
Shell escape command in run container entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.6.3
+- Shell-escape command in run container entrypoint
+
 # v13.6.2
 - Only build/push images relevant to relevant container contexts during a deploy
 

--- a/kubetools/dev/backends/docker_compose/__init__.py
+++ b/kubetools/dev/backends/docker_compose/__init__.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 
 from time import sleep
 
@@ -295,7 +296,7 @@ def run_container(kubetools_config, container, command, envvars=None):
     if envvars:
         compose_command.extend(['-e{0}'.format(e) for e in envvars])
 
-    compose_command.extend(["--entrypoint", " ".join(command)])
+    compose_command.extend(['--entrypoint', ' '.join(shlex.quote(arg) for arg in command)])
     compose_command.append(container)
 
     run_compose_process(kubetools_config, compose_command)


### PR DESCRIPTION
## Purpose of PR

Example  of a problematic command:

```
command: [
  curl, -X, PUT,
  'http://example.com/_mapping',
  -H, 'Content-Type: application/json',
  -d@/opt/mappings/mappings.json
]
```

Here the current code would not correctly escape quotes on the `Content-Type` section and the space inside would be interpreted by the shell.