### PR TITLE
Update container run to avoid escaping single commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.7.4
+- Avoid shell escaping full command strings
+
 # v13.7.3
 - Add option to cleanup command for cleaning up completed jobs
 

--- a/kubetools/dev/backends/docker_compose/__init__.py
+++ b/kubetools/dev/backends/docker_compose/__init__.py
@@ -296,7 +296,12 @@ def run_container(kubetools_config, container, command, envvars=None):
     if envvars:
         compose_command.extend(['-e{0}'.format(e) for e in envvars])
 
-    compose_command.extend(['--entrypoint', ' '.join(shlex.quote(arg) for arg in command)])
+    escaped_command = command
+    if len(command) > 1:
+        # ensure any individual elements of a command with spaces in them
+        # are quoted properly
+        escaped_command = ' '.join(shlex.quote(arg) for arg in command)
+    compose_command.extend(['--entrypoint', escaped_command])
     compose_command.append(container)
 
     run_compose_process(kubetools_config, compose_command)


### PR DESCRIPTION
## Purpose of PR

If a full command with spaces is passed to `ktd run` my previous change to escape elements will wrap the whole command in quotes, causing it to fail. 

As an example `ktd run container "python scripts/blah.py --argument"` ends up being translated to entrypoint of `"'python scripts/blah.py --argument'"` (notice double quoting).

This change updates to only shell quote individual elements of a command that is passed in multiple parts.