### PR TITLE
Allow customisation of naming in job configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.8.0
+- Allow customisation of naming in job configuration
+
 # v13.7.5
 - Ensure command format is correct for full command strings
 

--- a/tests/configs/basic_app/k8s_jobs.yml
+++ b/tests/configs/basic_app/k8s_jobs.yml
@@ -20,6 +20,7 @@ spec:
         command: [generic-command]
         env:
         - {name: KUBE, value: 'true'}
+        - {name: KUBE_JOB_ID, value: UUID}
         image: generic-image
         imagePullPolicy: Always
         name: upgrade

--- a/tests/test_make_job_config.py
+++ b/tests/test_make_job_config.py
@@ -1,0 +1,39 @@
+from os import path
+from unittest import TestCase
+
+from kubetools.config import load_kubetools_config
+from kubetools.kubernetes.config import make_job_config
+
+
+def load_job_spec():
+    app_dir = path.join('tests', 'configs', 'basic_app')
+    kubetools_config = load_kubetools_config(app_dir)
+    return kubetools_config.get('upgrades')[0]
+
+
+class TestMakeJobConfig(TestCase):
+    def test_job_id_is_added_to_envvars(self):
+        job_config = make_job_config(load_job_spec())
+        container_env = job_config['spec']['template']['spec']['containers'][0]['env']
+        self.assertIn('KUBE_JOB_ID', [env['name'] for env in container_env])
+
+    def test_job_name_defaults_to_job_id(self):
+        job_config = make_job_config(load_job_spec())
+        job_name = job_config['metadata']['name']
+        job_id = job_config['metadata']['labels']['job-id']
+        self.assertEqual(job_name, job_id)
+
+    def test_job_name_can_be_set_by_caller(self):
+        job_config = make_job_config(load_job_spec(), job_name='myawesomejob')
+        job_name = job_config['metadata']['name']
+        self.assertEqual('myawesomejob', job_name)
+
+    def test_container_name_defaults_to_upgrade(self):
+        job_config = make_job_config(load_job_spec())
+        container_name = job_config['spec']['template']['spec']['containers'][0]['name']
+        self.assertEqual('upgrade', container_name)
+
+    def test_container_name_can_be_set_by_caller(self):
+        job_config = make_job_config(load_job_spec(), container_name='mycoolcontainer')
+        container_name = job_config['spec']['template']['spec']['containers'][0]['name']
+        self.assertEqual('mycoolcontainer', container_name)


### PR DESCRIPTION
## Purpose of PR

- Allow job name to be set to something other than job id
- Allow container name to be set to something other than 'upgrade'
- Give container visibility of job id via environment variable