### PR TITLE
Pin docker compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.8.1
+- Pin docker-compose as v2 breaks docker naming convention
+
 # v13.8.0
 - Allow customisation of naming in job configuration
 

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ if __name__ == '__main__':
             'setuptools',
             'kubernetes',
             'tabulate<1',
+            # compose v2 has broken container naming
+            'docker-compose<2',
         ),
         extras_require={
             'dev': (


### PR DESCRIPTION
## Purpose of PR
Rewrite of docker-compose into go for v2 has broken some naming conventions, pin compose for now

## Parts of the app this will impact

## Todos

## Additional information

## Related links