### PR TITLE
pin docker-compose <1.29 as it requires docker v5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ if __name__ == '__main__':
             'kubernetes',
             'tabulate<1',
             # compose v2 has broken container naming
-            'docker-compose<2',
+            # and compose 1.29 requires docker >5
+            'docker-compose<1.29',
         ),
         extras_require={
             'dev': (


### PR DESCRIPTION
## Purpose of PR
At the moment if you install kubetools it will install `1.29.*`, which breaks due to:
```
pkg_resources.ContextualVersionConflict: (docker 4.4.4 (/Users/ryanmccorry/.pyenv/versions/3.7.6/lib/python3.7/site-packages), Requirement.parse('docker[ssh]>=5'), {'docker-compose'})
```
## Parts of the app this will impact

## Todos

## Additional information

## Related links