### PR TITLE
Try to avoid duplicated dev networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.10.0
+- Fix bug where 2 concurrent `ktd` commands could create a duplicated `dev` network
+
 # v13.9.0
 - Add CronJob object
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ### Unreleased
 
-# v13.10.0
-- Fix bug where 2 concurrent `ktd` commands could create a duplicated `dev` network
-
 # v13.9.0
-- Add CronJob object
+- Add support for creating CronJob objects in k8s
+- Fix bug where 2 concurrent `ktd` commands could create a duplicated `dev` network
+- Small optimisation for checking presence of image in registry
 
 # v13.8.1
 - Pin docker-compose as v2 breaks docker naming convention


### PR DESCRIPTION
Thanks @DilaraOflaz for the deep investigation of the root cause.

The problem appeared when 2 ktd commands are run simultaneously and the dev network did
not exist prior to the commands being run. Then each command mawy create the network
separately, without the docker daemon complaining about it.

Note that this may not fix 100% of cases (both networks might end up being removed) but at least it will leave the system in a state where retrying will work.