### PR TITLE
Add support for job time to live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.9.4
+- Added support job time to live
+
 # v13.9.3
 - Add support for CronJob api version `batch/v1beta1`
 

--- a/kubetools/kubernetes/config/job.py
+++ b/kubetools/kubernetes/config/job.py
@@ -75,7 +75,7 @@ def make_job_config(
     # Parallelism defaults to completions, also as Kubernetes
     parallelism = config.get('parallelism', completions)
 
-    return {
+    job_config = {
         # Normal Kubernetes job config
         'apiVersion': 'batch/v1',
         'kind': 'Job',
@@ -99,3 +99,8 @@ def make_job_config(
             },
         },
     }
+
+    if 'ttl_seconds_after_finished' in config:
+        job_config['spec']['ttlSecondsAfterFinished'] = config.get('ttl_seconds_after_finished')
+
+    return job_config

--- a/setup.py
+++ b/setup.py
@@ -68,9 +68,9 @@ if __name__ == '__main__':
                 'ipdb',
                 'pytest~=6.0',
                 'pytest-cov~=2.10',
-                'flake8~=3.8',
-                'flake8-import-order~=0.18',
-                'flake8-commas~=2.0',
+                'flake8',
+                'flake8-import-order',
+                'flake8-commas',
             ),
         },
         classifiers=[

--- a/tests/test_make_job_config.py
+++ b/tests/test_make_job_config.py
@@ -47,3 +47,14 @@ class TestMakeJobConfig(TestCase):
         job_config = make_job_config(load_job_spec())
         resource_config = job_config['spec']['template']['spec']['containers'][0]['resources']
         self.assertEqual(expected_resources, resource_config)
+
+    def test_ttl_is_set_if_provided_in_config(self):
+        job_spec = load_job_spec()
+        ttl_option = {'ttl_seconds_after_finished': 100}
+        job_spec.update(ttl_option)
+        job_config = make_job_config(job_spec)
+        self.assertIn('ttlSecondsAfterFinished', job_config['spec'])
+        self.assertEqual(
+                job_config['spec']['ttlSecondsAfterFinished'],
+                ttl_option['ttl_seconds_after_finished'],
+        )


### PR DESCRIPTION
Failure to remove resources used by completed jobs/pods can lead to resource exhaustion in the Kubernetes cluster. This commit adds support for setting a ttlSecondsAfterFinished parameter in the Kubernetes Job sepc. This parameter specifies the amount of time (in seconds) for which the resources used by completed job/pod will persist after it which it will be garbage collected by the Kube control manager.

The newly added parameter is optional and only set if it passed in through the `config` argument to the `make_job_spec` method.

## Purpose of PR

## Parts of the app this will impact

## Todos

## Additional information

## Related links