### PR TITLE
Update optional default registry to be command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v13.9.5
+- Allow adding a default registry in command line instead of
+  specifying the registry in kubetools.yml file.
+
 # v13.9.4
 - Added support job time to live
 

--- a/kubetools/cli/generate_config.py
+++ b/kubetools/cli/generate_config.py
@@ -43,8 +43,12 @@ FORMATTERS = {
     'app_dir',
     type=click.Path(exists=True, file_okay=False),
 )
+@click.option(
+    '--default-registry',
+    help='Default registry for apps that do not specify.',
+)
 @click.pass_context
-def config(ctx, replicas, file, app_dir, formatter):
+def config(ctx, replicas, file, app_dir, formatter, default_registry):
     '''
     Generate and write out Kubernetes configs for a project.
     '''
@@ -55,6 +59,7 @@ def config(ctx, replicas, file, app_dir, formatter):
         kubetools_config,
         replicas=replicas,
         context_name_to_image=context_to_image,
+        default_registry=default_registry,
     )
 
     writer = FORMATTERS[formatter]

--- a/kubetools/deploy/commands/deploy.py
+++ b/kubetools/deploy/commands/deploy.py
@@ -90,6 +90,7 @@ def get_deploy_objects(
             context_name_to_image=context_to_image,
             base_annotations=annotations,
             replicas=replicas or 1,
+            default_registry=default_registry,
         )
 
         all_services.extend(services)

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -35,8 +35,19 @@ def _ensure_image(
     container, context_name_to_image,
     deployment_name=None,
     container_name=None,
+    default_registry=None,
 ):
     if 'image' in container:
+        registry_image = container['image'].split('/')
+        if len(registry_image) == 1:
+            # If the image is commonly available from DockerHub
+            if default_registry is None:
+                container['image'] = registry_image[0]
+
+            # If registry not specified in the kubetools.yml file
+            else:
+                image = container['image']
+                container['image'] = f'{default_registry}/{image}'
         return
 
     if 'containerContext' in container:
@@ -53,7 +64,12 @@ def _ensure_image(
     container['image'] = context_name_to_image[context_name]
 
 
-def _get_containers_data(containers, context_name_to_image, deployment_name):
+def _get_containers_data(
+    containers,
+    context_name_to_image,
+    deployment_name,
+    default_registry=None,
+):
     # Setup top level app service mapping all ports from all top level containers
     all_container_ports = []
     all_containers = {}
@@ -63,6 +79,7 @@ def _get_containers_data(containers, context_name_to_image, deployment_name):
         _ensure_image(
             data, context_name_to_image,
             deployment_name, container_name,
+            default_registry=default_registry,
         )
         all_containers[container_name] = data
 
@@ -119,6 +136,7 @@ def generate_kubernetes_configs_for_project(
     # Map of context name -> docker image - images are expected to be built by
     # something else (normally the kubetools server or ktd client).
     context_name_to_image=None,
+    default_registry=None,
 ):
     '''
     Builds service & deployment definitions based on the app config provided. We have
@@ -163,6 +181,7 @@ def generate_kubernetes_configs_for_project(
             dependency['containers'],
             context_name_to_image=context_name_to_image,
             deployment_name=name,
+            default_registry=default_registry,
         )
         app_annotations = copy_and_update(base_annotations)
 
@@ -196,6 +215,7 @@ def generate_kubernetes_configs_for_project(
             deployment['containers'],
             context_name_to_image=context_name_to_image,
             deployment_name=name,
+            default_registry=default_registry,
         )
         app_annotations = copy_and_update(
             base_annotations,
@@ -233,7 +253,7 @@ def generate_kubernetes_configs_for_project(
         job_specs = config.get('upgrades', []) + job_specs
 
     for job_spec in job_specs:
-        _ensure_image(job_spec, context_name_to_image)
+        _ensure_image(job_spec, context_name_to_image, default_registry=default_registry)
 
         # Stil no image? Let's pull the first container we have available - this
         # maintains backwards compatability where one can ask for a job without
@@ -284,6 +304,7 @@ def generate_kubernetes_configs_for_project(
             cronjob['containers'],
             context_name_to_image=context_name_to_image,
             deployment_name=name,
+            default_registry=default_registry,
         )
 
         app_annotations = copy_and_update(base_annotations)

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -39,15 +39,9 @@ def _ensure_image(
 ):
     if 'image' in container:
         registry_image = container['image'].split('/')
-        if len(registry_image) == 1:
-            # If the image is commonly available from DockerHub
-            if default_registry is None:
-                container['image'] = registry_image[0]
-
-            # If registry not specified in the kubetools.yml file
-            else:
-                image = container['image']
-                container['image'] = f'{default_registry}/{image}'
+        if len(registry_image) == 1 and default_registry is not None:
+            # If registry is not specified but a default was provided
+            container['image'] = f'{default_registry}/{container["image"]}'
         return
 
     if 'containerContext' in container:

--- a/tests/configs/docker_registry/k8s_deployments.yml
+++ b/tests/configs/docker_registry/k8s_deployments.yml
@@ -15,16 +15,15 @@ spec:
       labels: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
     spec:
       containers:
-      - command: [generic-command]
-        containerContext: generic-context
+      - command: [uwsgi, --ini, /etc/uwsgi.conf]
         env:
         - {name: KUBE, value: 'true'}
         image: generic-registry/generic-image
         imagePullPolicy: Always
-        name: with-default-registry
+        name: with-generic-registry
       - command: [uwsgi, --ini, /etc/uwsgi.conf]
         env:
         - {name: KUBE, value: 'true'}
         image: default-registry/generic-image
         imagePullPolicy: Always
-        name: without-default-registry
+        name: with-default-registry

--- a/tests/configs/docker_registry/k8s_deployments.yml
+++ b/tests/configs/docker_registry/k8s_deployments.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
+  name: generic-app
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: generic-app, kubetools/project_name: generic-app,
+      kubetools/role: app}
+  template:
+    metadata:
+      labels: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-registry/generic-image
+        imagePullPolicy: Always
+        name: with-default-registry
+      - command: [uwsgi, --ini, /etc/uwsgi.conf]
+        env:
+        - {name: KUBE, value: 'true'}
+        image: default-registry/generic-image
+        imagePullPolicy: Always
+        name: without-default-registry

--- a/tests/configs/docker_registry/k8s_services.yml
+++ b/tests/configs/docker_registry/k8s_services.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
+  name: generic-app
+spec:
+  ports:
+  - {port: 80, targetPort: 80}
+  - {port: 80, targetPort: 80}
+  selector: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
+  type: NodePort

--- a/tests/configs/docker_registry/k8s_services.yml
+++ b/tests/configs/docker_registry/k8s_services.yml
@@ -7,6 +7,6 @@ metadata:
 spec:
   ports:
   - {port: 80, targetPort: 80}
-  - {port: 80, targetPort: 80}
+  - {port: 9090, targetPort: 9090}
   selector: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
   type: NodePort

--- a/tests/configs/docker_registry/kubetools.yml
+++ b/tests/configs/docker_registry/kubetools.yml
@@ -15,4 +15,3 @@ deployments:
         command: [uwsgi, --ini, /etc/uwsgi.conf]
         ports:
           - 9090
-

--- a/tests/configs/docker_registry/kubetools.yml
+++ b/tests/configs/docker_registry/kubetools.yml
@@ -1,24 +1,18 @@
 name: generic-app
 
 
-containerContexts:
-  generic-context:
-    image: generic-registry/generic-image
-    command: [generic-command]
-    ports:
-      - 80
-
-
 deployments:
   generic-app:
     containers:
-      with-default-registry:
-        command: [uwsgi, --ini, /etc/uwsgi.conf]
-        containerContext: generic-context
-
-      without-default-registry:
-        image: generic-image
+      with-generic-registry:
+        image: generic-registry/generic-image
         command: [uwsgi, --ini, /etc/uwsgi.conf]
         ports:
           - 80
+
+      with-default-registry:
+        image: generic-image
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        ports:
+          - 9090
 

--- a/tests/configs/docker_registry/kubetools.yml
+++ b/tests/configs/docker_registry/kubetools.yml
@@ -1,0 +1,24 @@
+name: generic-app
+
+
+containerContexts:
+  generic-context:
+    image: generic-registry/generic-image
+    command: [generic-command]
+    ports:
+      - 80
+
+
+deployments:
+  generic-app:
+    containers:
+      with-default-registry:
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        containerContext: generic-context
+
+      without-default-registry:
+        image: generic-image
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        ports:
+          - 80
+

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -62,5 +62,5 @@ class TestKubernetesConfigGeneration(TestCase):
     def test_multiple_deployments_configs(self):
         _test_configs('multiple_deployments')
 
-    def test_registry_configs(self):
-        _test_configs('docker_registry', 'default-registry')
+    def test_docker_registry_configs(self):
+        _test_configs('docker_registry', default_registry='default-registry')

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -18,7 +18,7 @@ def _assert_yaml_objects(objects, yaml_filename):
     assert objects == desired_objects
 
 
-def _test_configs(folder_name, **kwargs):
+def _test_configs(folder_name, default_registry=None, **kwargs):
     app_dir = path.join('tests', 'configs', folder_name)
 
     kubetools_config = load_kubetools_config(app_dir, **kwargs)
@@ -26,6 +26,7 @@ def _test_configs(folder_name, **kwargs):
     with mock.patch('kubetools.kubernetes.config.job.uuid4', lambda: 'UUID'):
         services, deployments, jobs, cronjobs = generate_kubernetes_configs_for_project(
             kubetools_config,
+            default_registry=default_registry,
         )
 
     k8s_files = listdir(app_dir)
@@ -60,3 +61,6 @@ class TestKubernetesConfigGeneration(TestCase):
 
     def test_multiple_deployments_configs(self):
         _test_configs('multiple_deployments')
+
+    def test_registry_configs(self):
+        _test_configs('docker_registry', 'default-registry')


### PR DESCRIPTION
## Purpose of PR
Updated kubetools to use the default_registry argument as the prefix of images specified in `kubetools.yml` file, rather than expecting the registry name to be in the image name
