### PR TITLE
enable_ipv6_networks - Enabling support for IPv6

### DIFF
--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -40,7 +40,11 @@ def ensure_docker_dev_network():
     docker_client = get_docker_client()
 
     try:
-        new_network = docker_client.networks.create(name='dev', check_duplicate=True)
+        new_network = docker_client.networks.create(
+            name='dev',
+            check_duplicate=True,
+            enable_ipv6=True
+        )
     except docker.errors.APIError as e:
         if e.status_code != 409:
             raise


### PR DESCRIPTION
## Purpose of PR
At the moment IPv6 is not enabled in dev networks, so containers don't get ip address assigned. With this PR IPv6 is allowed on the network and is up to application if ipv4 or ipv6 will be used.

## Parts of the app this will impact
Network
## Todos

## Additional information
