### PR TITLE
Remove testing on deprecated Ubuntu18 platform

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-20.04, ubuntu-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
         exclude:
           # Python 3.6 is not available in GitHub Actions Ubuntu 22.04


### PR DESCRIPTION
Make tests pass by removing the testing on deprecated Ubuntu18 platform