### PR TITLE
Small fixes and cleanups

### DIFF
--- a/kubetools/cli/generate_config.py
+++ b/kubetools/cli/generate_config.py
@@ -62,28 +62,16 @@ def config(ctx, replicas, file, app_dir, output_format, default_registry):
         default_registry=default_registry,
     )
 
+    echo_resources(services, 'Service', output_format)
+    echo_resources(deployments, 'Deployment', output_format)
+    echo_resources(jobs, 'Job', output_format)
+    echo_resources(cronjobs, 'Cronjob', output_format)
+
+
+def echo_resources(resources, resource_kind, output_format):
     formatter = FORMATTERS[output_format]
-
-    for service in services:
-        name = get_object_name(service)
-        click.echo(f'Service: {click.style(name, bold=True)}')
-        click.echo(formatter(service))
-        click.echo()
-
-    for deployment in deployments:
-        name = get_object_name(deployment)
-        click.echo(f'Deployment: {click.style(name, bold=True)}')
-        click.echo(formatter(deployment))
-        click.echo()
-
-    for job in jobs:
-        name = get_object_name(job)
-        click.echo(f'Job: {click.style(name, bold=True)}')
-        click.echo(formatter(job))
-        click.echo()
-
-    for cronjob in cronjobs:
-        name = get_object_name(cronjob)
-        click.echo(f'Cronjob: {click.style(name, bold=True)}')
-        click.echo(formatter(cronjob))
+    for resource in resources:
+        name = get_object_name(resource)
+        click.echo(f'{resource_kind}: {click.style(name, bold=True)}')
+        click.echo(formatter(resource))
         click.echo()

--- a/kubetools/cli/generate_config.py
+++ b/kubetools/cli/generate_config.py
@@ -34,7 +34,7 @@ FORMATTERS = {
     type=click.Path(exists=True),
 )
 @click.option(
-    '--format', 'formatter',
+    '--format', 'output_format',
     type=click.Choice(('json', 'yaml')),
     default='json',
     help='Specify the output format',
@@ -48,7 +48,7 @@ FORMATTERS = {
     help='Default registry for apps that do not specify.',
 )
 @click.pass_context
-def config(ctx, replicas, file, app_dir, formatter, default_registry):
+def config(ctx, replicas, file, app_dir, output_format, default_registry):
     '''
     Generate and write out Kubernetes configs for a project.
     '''
@@ -62,28 +62,28 @@ def config(ctx, replicas, file, app_dir, formatter, default_registry):
         default_registry=default_registry,
     )
 
-    writer = FORMATTERS[formatter]
+    formatter = FORMATTERS[output_format]
 
     for service in services:
         name = get_object_name(service)
         click.echo(f'Service: {click.style(name, bold=True)}')
-        click.echo(writer(service))
+        click.echo(formatter(service))
         click.echo()
 
     for deployment in deployments:
         name = get_object_name(deployment)
         click.echo(f'Deployment: {click.style(name, bold=True)}')
-        click.echo(writer(deployment))
+        click.echo(formatter(deployment))
         click.echo()
 
     for job in jobs:
         name = get_object_name(job)
         click.echo(f'Job: {click.style(name, bold=True)}')
-        click.echo(writer(job))
+        click.echo(formatter(job))
         click.echo()
 
     for cronjob in cronjobs:
         name = get_object_name(cronjob)
         click.echo(f'Cronjob: {click.style(name, bold=True)}')
-        click.echo(writer(cronjob))
+        click.echo(formatter(cronjob))
         click.echo()

--- a/kubetools/deploy/commands/cleanup.py
+++ b/kubetools/deploy/commands/cleanup.py
@@ -75,7 +75,7 @@ def get_cleanup_objects(build, cleanup_jobs):
         replica_set_names - replica_set_names_to_delete - replica_set_names_already_deleted
     )
 
-    if len(remaining_pods) == 0 and len(remaining_replicasets) == 0:
+    if current_namespace and len(remaining_pods) == 0 and len(remaining_replicasets) == 0:
         namespace_to_delete = [current_namespace]
 
     return namespace_to_delete, replica_sets_to_delete, pods_to_delete, jobs_to_delete

--- a/kubetools/deploy/commands/cleanup.py
+++ b/kubetools/deploy/commands/cleanup.py
@@ -64,19 +64,23 @@ def get_cleanup_objects(build, cleanup_jobs):
             pod_names_already_deleted.add(get_object_name(pod))
 
     namespaces = list_namespaces(build.env)
-    current_namespace = None
     for namespace in namespaces:
         if namespace.metadata.name == build.namespace:
             current_namespace = namespace
+            break
+    else:
+        current_namespace = None
 
     namespace_to_delete = []
-    remaining_pods = pod_names - pod_names_to_delete - pod_names_already_deleted
-    remaining_replicasets = (
-        replica_set_names - replica_set_names_to_delete - replica_set_names_already_deleted
-    )
+    # Namespace must exist. And "default" namespace can't be deleted
+    if current_namespace and current_namespace.metadata.name != "default":
+        remaining_pods = pod_names - pod_names_to_delete - pod_names_already_deleted
+        remaining_replicasets = (
+                replica_set_names - replica_set_names_to_delete - replica_set_names_already_deleted
+        )
 
-    if current_namespace and len(remaining_pods) == 0 and len(remaining_replicasets) == 0:
-        namespace_to_delete = [current_namespace]
+        if len(remaining_pods) == 0 and len(remaining_replicasets) == 0:
+            namespace_to_delete = [current_namespace]
 
     return namespace_to_delete, replica_sets_to_delete, pods_to_delete, jobs_to_delete
 

--- a/kubetools/kubernetes/api.py
+++ b/kubetools/kubernetes/api.py
@@ -17,7 +17,12 @@ def get_object_labels_dict(obj):
 
 
 def get_object_annotations_dict(obj):
-    return obj.metadata.annotations or obj.spec.template.metadata.annotations or {}
+    if hasattr(obj.metadata, "annotations") and obj.metadata.annotations:
+        return obj.metadata.annotations
+    elif hasattr(obj.metadata, "template"):
+        return get_object_annotations_dict(obj.spec.template)
+    else:
+        return {}
 
 
 def get_object_name(obj):


### PR DESCRIPTION
## Purpose of PR
* Small cleanups as seen during my work on #147 
* Fix issues with k8s namespace handling:
  * the "default" namespace cannot be deleted, that's forbidden by k8s
  * don't try to delete the target namespace if it doesn't even exist
* Fix a bug with gathering annotations when some objects in the namespace may not have any. This happens only if the kubetools application is deployed to a namespace shared with resources deployed with other tools, and that may not have any annotations, or even be of a Kind that doesn't allow annotations.