### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,8 +19,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      # See https://github.com/yaml/pyyaml/issues/601
+      - name: Add cython constraint
+        run: 'echo "cython<3" > /tmp/constraint.txt'
       - name: Install package
-        run: python -m pip install .[dev]
+        run: PIP_CONSTRAINT=/tmp/constraint.txt python -m pip install .[dev]
       - name: Linting
         run: "flake8"
       - name: Unit tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+- Cython 3.0 release is preventing this package to be released. A constraint of `cython<3` needs to be added to install this.
 
 # v13.12.1
 - De-couple serviceAccountName and secrets

--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ kubetools deploy my-namespace
 pip install kubetools
 ```
 
+**NOTE**: Since Cython 3.0 was released, the installation of `kubetools` dependencies will fail
+ due to compatibility issues between Cython 3 and PyYaml (see
+ [this issue](https://github.com/yaml/pyyaml/issues/601)). This can be worked around for example
+ with `pip` by using a "constraints" file containing `cython<3`.
+
 ## Configuration
 Users can configure some aspects of `kubetools`. The configuration folder location depends on the
 operating system of the user. See the

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if __name__ == '__main__':
             'click>=7,<8',
             'docker>=3,<5',
             'pyyaml>=3,<6',
-            'requests>=2,<3',
+            'requests>=2,<2.29.0',  # https://github.com/docker/docker-py/issues/3113
             'pyretry',
             'setuptools',
             # To support CronJob api versions 'batch/v1beta1' & 'batch/v1'


### PR DESCRIPTION
This fixes 2 separate problems that showed up with releases within dependencies:
* Cython 3 release broke PyYaml installation. This can be worked around by adding a constraint for Cython version upon install.
* Urllib3 release 2.0 broke the `requests` package used by `docker-py`. Since we also depend directly on `requests, we work this around by pinning it to a compatible version.

Note that these are work-around for the current state of the tool. They should be removed once a proper upgrading of dependencies is done.