### PR TITLE
add support for dnsConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ### Unreleased
-
+# v13.14.0
+- Add support for dnsConfiguration from PodSpec
+- 
 # v13.13.0
 - Cython 3.0 release is preventing this package to be released. A constraint of `cython<3` needs to be added to install this
 - Add ability to use secrets in "migration" jobs

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -212,6 +212,7 @@ def generate_kubernetes_configs_for_project(
 
         service_account_name = deployment.get('serviceAccountName', None)
         secrets = deployment.get('secrets', None)
+        dns_config = deployment.get('dnsConfig', None)
 
         containers, container_ports = _get_containers_data(
             deployment['containers'],
@@ -244,6 +245,7 @@ def generate_kubernetes_configs_for_project(
             update_strategy=deployment.get('updateStrategy'),
             service_account_name=service_account_name,
             secrets=secrets,
+            dns_config=dns_config,
         ))
 
     # Jobs can be upgrades and/or passed in as part of the build spec

--- a/kubetools/kubernetes/config/deployment.py
+++ b/kubetools/kubernetes/config/deployment.py
@@ -14,6 +14,7 @@ def make_deployment_config(
     update_strategy=None,
     service_account_name=None,
     secrets=None,
+    dns_config=None,
 ):
     '''
     Builds a Kubernetes deployment configuration dict.
@@ -47,6 +48,9 @@ def make_deployment_config(
                 secret_name, secret,
             ))
         template_spec['volumes'] = kubernetes_volumes
+
+    if dns_config is not None:
+        template_spec['dnsConfig'] = dns_config
 
     # The actual controller Kubernetes config
     controller = {

--- a/tests/configs/k8s_with_dns_config/k8s_deployments.yml
+++ b/tests/configs/k8s_with_dns_config/k8s_deployments.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: generic-app-with-dnsConfig-generic-deployment-with-dnsConfig, kubetools/project_name: generic-app-with-dnsConfig,
+  kubetools/role: app}
+  name: generic-app-with-dnsConfig-generic-deployment-with-dnsConfig
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: generic-app-with-dnsConfig-generic-deployment-with-dnsConfig, kubetools/project_name: generic-app-with-dnsConfig,
+      kubetools/role: app}
+  template:
+    metadata:
+      labels: {kubetools/name: generic-app-with-dnsConfig-generic-deployment-with-dnsConfig, kubetools/project_name: generic-app-with-dnsConfig,
+        kubetools/role: app}
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        name: generic-deployment-workers
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"

--- a/tests/configs/k8s_with_dns_config/kubetools.yml
+++ b/tests/configs/k8s_with_dns_config/kubetools.yml
@@ -1,0 +1,16 @@
+name: generic-app-with-dnsConfig
+
+containerContexts:
+  generic-context:
+    image: generic-image
+    command: [generic-command]
+
+deployments:
+  generic-deployment-with-dnsConfig:
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "1"
+    containers:
+      generic-deployment-workers:
+        containerContext: generic-context

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -34,6 +34,9 @@ class TestKubernetesConfigGeneration(TestCase):
     def test_k8s_with_mounted_secrets_configs(self):
         _test_configs('k8s_with_mounted_secrets')
 
+    def test_k8s_with_dns_config(self):
+        _test_configs('k8s_with_dns_config')
+
 
 def _test_configs(folder_name, default_registry=None, **kwargs):
     app_dir = path.join('tests', 'configs', folder_name)


### PR DESCRIPTION
This PR allows setting `dnsConfig` for the [PodSpec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec) in kubetools.