### PR TITLE
Add ability to configure nodeSelector labels for k8s configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.13.1
+- Add nodeSelector config to kubetools file
+
 # v13.13.0
 - Cython 3.0 release is preventing this package to be released. A constraint of `cython<3` needs to be added to install this
 - Add ability to use secrets in "migration" jobs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ### Unreleased
-- Fix bug where `config` command was not printing the actual `k8s` configs used by `deploy` because it did not take into account the kube-context, whether default or given with `--context`.
 
 # v13.13.1
 - Add nodeSelector config to kubetools file
+- Fix bug where `config` command was not printing the actual `k8s` configs used by `deploy` because it did not take into account the kube-context, whether default or given with `--context`.
 
 # v13.13.0
 - Cython 3.0 release is preventing this package to be released. A constraint of `cython<3` needs to be added to install this

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -171,6 +171,7 @@ def generate_kubernetes_configs_for_project(
             NAME_LABEL_KEY: dependency_name,
         })
 
+        node_selector_labels = dependency.get('nodeSelector', None)
         service_account_name = dependency.get('serviceAccountName', None)
         secrets = dependency.get('secrets', None)
 
@@ -199,6 +200,7 @@ def generate_kubernetes_configs_for_project(
             annotations=app_annotations,
             envvars=envvars,
             update_strategy=dependency.get('updateStrategy'),
+            node_selector_labels=node_selector_labels,
             service_account_name=service_account_name,
             secrets=secrets,
         ))
@@ -210,6 +212,7 @@ def generate_kubernetes_configs_for_project(
             NAME_LABEL_KEY: deployment_name,
         })
 
+        node_selector_labels = deployment.get('nodeSelector', None)
         service_account_name = deployment.get('serviceAccountName', None)
         secrets = deployment.get('secrets', None)
 
@@ -242,6 +245,7 @@ def generate_kubernetes_configs_for_project(
             annotations=app_annotations,
             envvars=envvars,
             update_strategy=deployment.get('updateStrategy'),
+            node_selector_labels=node_selector_labels,
             service_account_name=service_account_name,
             secrets=secrets,
         ))
@@ -287,6 +291,7 @@ def generate_kubernetes_configs_for_project(
             job_spec.get('envvars'),
         )
 
+        node_selector_labels = job_spec.get('nodeSelector', None)
         service_account_name = job_spec.get('serviceAccountName', None)
         secrets = job_spec.get('secrets', None)
 
@@ -296,6 +301,7 @@ def generate_kubernetes_configs_for_project(
             labels=job_labels,
             annotations=base_annotations,
             envvars=job_envvars,
+            node_selector_labels=node_selector_labels,
             service_account_name=service_account_name,
             secrets=secrets,
         ))
@@ -308,6 +314,7 @@ def generate_kubernetes_configs_for_project(
             NAME_LABEL_KEY: name,
         })
 
+        node_selector_labels = cronjob.get('nodeSelector', None)
         service_account_name = cronjob.get('serviceAccountName', None)
         secrets = cronjob.get('secrets', None)
 
@@ -333,6 +340,7 @@ def generate_kubernetes_configs_for_project(
             labels=cronjob_labels,
             annotations=app_annotations,
             envvars=envvars,
+            node_selector_labels=node_selector_labels,
             service_account_name=service_account_name,
             secrets=secrets,
         ))

--- a/kubetools/kubernetes/config/cronjob.py
+++ b/kubetools/kubernetes/config/cronjob.py
@@ -15,6 +15,7 @@ def make_cronjob_config(
     labels=None,
     annotations=None,
     envvars=None,
+    node_selector_labels=None,
     service_account_name=None,
     secrets=None,
 ):
@@ -53,6 +54,12 @@ def make_cronjob_config(
         'restartPolicy': 'OnFailure',
         'containers': kubernetes_containers,
     }
+
+    if node_selector_labels is not None:
+        selector_labels = []
+        for label, value in node_selector_labels.items():
+            selector_labels.append({label: value})
+        template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/kubetools/kubernetes/config/cronjob.py
+++ b/kubetools/kubernetes/config/cronjob.py
@@ -56,10 +56,7 @@ def make_cronjob_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = {}
-        for label, value in node_selector_labels.items():
-            selector_labels[label] = value
-        template_spec['nodeSelector'] = selector_labels
+        template_spec['nodeSelector'] = node_selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/kubetools/kubernetes/config/cronjob.py
+++ b/kubetools/kubernetes/config/cronjob.py
@@ -56,9 +56,9 @@ def make_cronjob_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = []
+        selector_labels = {}
         for label, value in node_selector_labels.items():
-            selector_labels.append({label: value})
+            selector_labels[label] = value
         template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:

--- a/kubetools/kubernetes/config/deployment.py
+++ b/kubetools/kubernetes/config/deployment.py
@@ -12,6 +12,7 @@ def make_deployment_config(
     annotations=None,
     envvars=None,
     update_strategy=None,
+    node_selector_labels=None,
     service_account_name=None,
     secrets=None,
 ):
@@ -36,6 +37,12 @@ def make_deployment_config(
     template_spec = {
         'containers': kubernetes_containers,
     }
+
+    if node_selector_labels is not None:
+        selector_labels = []
+        for label, value in node_selector_labels.items():
+            selector_labels.append({label: value})
+        template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/kubetools/kubernetes/config/deployment.py
+++ b/kubetools/kubernetes/config/deployment.py
@@ -39,9 +39,9 @@ def make_deployment_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = []
+        selector_labels = {}
         for label, value in node_selector_labels.items():
-            selector_labels.append({label: value})
+            selector_labels[label] = value
         template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:

--- a/kubetools/kubernetes/config/deployment.py
+++ b/kubetools/kubernetes/config/deployment.py
@@ -39,10 +39,7 @@ def make_deployment_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = {}
-        for label, value in node_selector_labels.items():
-            selector_labels[label] = value
-        template_spec['nodeSelector'] = selector_labels
+        template_spec['nodeSelector'] = node_selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/kubetools/kubernetes/config/job.py
+++ b/kubetools/kubernetes/config/job.py
@@ -86,9 +86,9 @@ def make_job_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = []
+        selector_labels = {}
         for label, value in node_selector_labels.items():
-            selector_labels.append({label: value})
+            selector_labels[label] = value
         template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:

--- a/kubetools/kubernetes/config/job.py
+++ b/kubetools/kubernetes/config/job.py
@@ -86,10 +86,7 @@ def make_job_config(
     }
 
     if node_selector_labels is not None:
-        selector_labels = {}
-        for label, value in node_selector_labels.items():
-            selector_labels[label] = value
-        template_spec['nodeSelector'] = selector_labels
+        template_spec['nodeSelector'] = node_selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/kubetools/kubernetes/config/job.py
+++ b/kubetools/kubernetes/config/job.py
@@ -14,6 +14,7 @@ def make_job_config(
     envvars=None,
     job_name=None,
     container_name="upgrade",
+    node_selector_labels=None,
     service_account_name=None,
     secrets=None,
 ):
@@ -83,6 +84,12 @@ def make_job_config(
         'restartPolicy': 'Never',
         'containers': [container],
     }
+
+    if node_selector_labels is not None:
+        selector_labels = []
+        for label, value in node_selector_labels.items():
+            selector_labels.append({label: value})
+        template_spec['nodeSelector'] = selector_labels
 
     if service_account_name is not None:
         template_spec['serviceAccountName'] = service_account_name

--- a/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
@@ -39,6 +39,5 @@ spec:
             name: generic-container
           restartPolicy: OnFailure
           nodeSelector:
-          - nodeLabel: generic-label-value
-            nodeLabelName: generic-node-name 
-          
+          - nodeLabelName: node-upgrades
+            nodeLabelOS: amd64

--- a/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
@@ -1,0 +1,44 @@
+kind: CronJob
+metadata:
+  name: generic-cronjob
+  labels: {
+    kubetools/name: generic-cronjob,
+    kubetools/project_name: generic-app-with-node-selectors,
+    kubetools/role: cronjob
+  }
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    description: 'Run: [''generic-command'']'
+  }
+spec:
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 10
+  concurrencyPolicy: "Allow"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: generic-cronjob
+          labels: {
+            kubetools/name: generic-cronjob,
+            kubetools/project_name: generic-app-with-node-selectors,
+            kubetools/role: cronjob
+          }
+          annotations: {
+            app.kubernetes.io/managed-by: kubetools,
+            description: 'Run: [''generic-command'']'
+          }
+        spec:
+          containers:
+          - command: [generic-command]
+            containerContext: generic-context
+            env:
+            - {name: KUBE, value: 'true'}
+            image: generic-image
+            imagePullPolicy: 'Always'
+            name: generic-container
+          restartPolicy: OnFailure
+          nodeSelector:
+          - nodeLabel: generic-label-value
+            nodeLabelName: generic-node-name 
+          

--- a/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_cronjobs.yml
@@ -40,4 +40,4 @@ spec:
           restartPolicy: OnFailure
           nodeSelector:
           - nodeLabelName: node-upgrades
-            nodeLabelOS: amd64
+            nodeLabelOS: ubuntu22

--- a/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: generic-app-with-node-selectors-generic-deployment-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+  kubetools/role: app}
+  name: generic-app-with-node-selectors-generic-deployment-with-node-selectors
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: generic-app-with-node-selectors-generic-deployment-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+      kubetools/role: app}
+  template:
+    metadata:
+      labels: {kubetools/name: generic-app-with-node-selectors-generic-deployment-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+        kubetools/role: app}
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        name: generic-deployment-workers
+      nodeSelector:
+      - nodeLabel: generic-label-value
+        nodeLabelName: generic-node-name 
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: generic-app-with-node-selectors-generic-dependency-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+    kubetools/role: dependency}
+  name: generic-app-with-node-selectors-generic-dependency-with-node-selectors
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: generic-app-with-node-selectors-generic-dependency-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+      kubetools/role: dependency}
+  template:
+    metadata:
+      labels: {kubetools/name: generic-app-with-node-selectors-generic-dependency-with-node-selectors, kubetools/project_name: generic-app-with-node-selectors,
+        kubetools/role: dependency}
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        name: generic-dependency
+      nodeSelector:
+      - nodeLabel: generic-label-value
+        nodeLabelName: generic-node-name 

--- a/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
@@ -26,7 +26,7 @@ spec:
         name: generic-deployment-workers
       nodeSelector:
       - nodeLabelName: node-deployments
-        nodeLabelOS: amd64
+        nodeLabelOS: ubuntu22
 
 ---
 
@@ -58,4 +58,4 @@ spec:
         name: generic-dependency
       nodeSelector:
       - nodeLabelName: node-dependencies
-        nodeLabelOS: amd64 
+        nodeLabelOS: ubuntu22

--- a/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_deployments.yml
@@ -25,8 +25,8 @@ spec:
         imagePullPolicy: Always
         name: generic-deployment-workers
       nodeSelector:
-      - nodeLabel: generic-label-value
-        nodeLabelName: generic-node-name 
+      - nodeLabelName: node-deployments
+        nodeLabelOS: amd64
 
 ---
 
@@ -57,5 +57,5 @@ spec:
         imagePullPolicy: Always
         name: generic-dependency
       nodeSelector:
-      - nodeLabel: generic-label-value
-        nodeLabelName: generic-node-name 
+      - nodeLabelName: node-dependencies
+        nodeLabelOS: amd64 

--- a/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
@@ -27,5 +27,5 @@ spec:
         resources: {}
       restartPolicy: Never
       nodeSelector:
-      - nodeLabel: generic-label-value
-        nodeLabelName: generic-node-name 
+      - nodeLabelName: node-upgrades
+        nodeLabelOS: amd64

--- a/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
@@ -28,4 +28,4 @@ spec:
       restartPolicy: Never
       nodeSelector:
       - nodeLabelName: node-upgrades
-        nodeLabelOS: amd64
+        nodeLabelOS: ubuntu22

--- a/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
+++ b/tests/configs/k8s_with_node_selectors/k8s_jobs.yml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools, description: 'Run: [''generic-command'']'}
+  labels: {job-id: UUID, kubetools/project_name: generic-app-with-node-selectors,
+    kubetools/role: job}
+  name: UUID
+spec:
+  completions: 1
+  parallelism: 1
+  selector: {job-id: UUID, kubetools/project_name: generic-app-with-node-selectors,
+    kubetools/role: job}
+  template:
+    metadata:
+      labels: {job-id: UUID, kubetools/project_name: generic-app-with-node-selectors,
+        kubetools/role: job}
+    spec:
+      containers:
+      - chdir: /
+        command: [generic-command]
+        env:
+        - {name: KUBE, value: 'true'}
+        - {name: KUBE_JOB_ID, value: UUID}
+        image: generic-image
+        imagePullPolicy: Always
+        name: upgrade
+        resources: {}
+      restartPolicy: Never
+      nodeSelector:
+      - nodeLabel: generic-label-value
+        nodeLabelName: generic-node-name 

--- a/tests/configs/k8s_with_node_selectors/kubetools.yml
+++ b/tests/configs/k8s_with_node_selectors/kubetools.yml
@@ -1,0 +1,44 @@
+name: generic-app-with-node-selectors
+
+containerContexts:
+  generic-context:
+    image: generic-image
+    command: [generic-command]
+
+upgrades:
+  - name: Upgrade the database
+    containerContext: generic-context
+    nodeSelector:
+      nodeLabel: generic-label-value
+      nodeLabelName: generic-node-name
+
+dependencies:
+  generic-dependency-with-node-selectors:
+    nodeSelector:
+      nodeLabel: generic-label-value
+      nodeLabelName: generic-node-name
+    containers:
+      generic-dependency:
+        containerContext: generic-context
+
+
+deployments:
+  generic-deployment-with-node-selectors:
+    nodeSelector:
+      nodeLabel: generic-label-value
+      nodeLabelName: generic-node-name
+    containers:
+      generic-deployment-workers:
+        containerContext: generic-context
+
+
+cronjobs:
+  generic-cronjob-with-node-selectors:
+    schedule: "*/1 * * * *"
+    concurrency_policy: "Allow"
+    nodeSelector:
+      nodeLabel: generic-label-value
+      nodeLabelName: generic-node-name
+    containers:
+      generic-container:
+        containerContext: generic-context

--- a/tests/configs/k8s_with_node_selectors/kubetools.yml
+++ b/tests/configs/k8s_with_node_selectors/kubetools.yml
@@ -10,13 +10,13 @@ upgrades:
     containerContext: generic-context
     nodeSelector:
       nodeLabelName: node-upgrades
-      nodeLabelOS: amd64
+      nodeLabelOS: ubuntu22
 
 dependencies:
   generic-dependency-with-node-selectors:
     nodeSelector:
       nodeLabelName: node-dependencies
-      nodeLabelOS: amd64
+      nodeLabelOS: ubuntu22
     containers:
       generic-dependency:
         containerContext: generic-context
@@ -26,7 +26,7 @@ deployments:
   generic-deployment-with-node-selectors:
     nodeSelector:
       nodeLabelName: node-deployments
-      nodeLabelOS: amd64
+      nodeLabelOS: ubuntu22
     containers:
       generic-deployment-workers:
         containerContext: generic-context
@@ -38,7 +38,7 @@ cronjobs:
     concurrency_policy: "Allow"
     nodeSelector:
       nodeLabelName: node-cronjobs
-      nodeLabelOS: amd64
+      nodeLabelOS: ubuntu22
     containers:
       generic-container:
         containerContext: generic-context

--- a/tests/configs/k8s_with_node_selectors/kubetools.yml
+++ b/tests/configs/k8s_with_node_selectors/kubetools.yml
@@ -9,14 +9,14 @@ upgrades:
   - name: Upgrade the database
     containerContext: generic-context
     nodeSelector:
-      nodeLabel: generic-label-value
-      nodeLabelName: generic-node-name
+      nodeLabelName: node-upgrades
+      nodeLabelOS: amd64
 
 dependencies:
   generic-dependency-with-node-selectors:
     nodeSelector:
-      nodeLabel: generic-label-value
-      nodeLabelName: generic-node-name
+      nodeLabelName: node-dependencies
+      nodeLabelOS: amd64
     containers:
       generic-dependency:
         containerContext: generic-context
@@ -25,8 +25,8 @@ dependencies:
 deployments:
   generic-deployment-with-node-selectors:
     nodeSelector:
-      nodeLabel: generic-label-value
-      nodeLabelName: generic-node-name
+      nodeLabelName: node-deployments
+      nodeLabelOS: amd64
     containers:
       generic-deployment-workers:
         containerContext: generic-context
@@ -37,8 +37,8 @@ cronjobs:
     schedule: "*/1 * * * *"
     concurrency_policy: "Allow"
     nodeSelector:
-      nodeLabel: generic-label-value
-      nodeLabelName: generic-node-name
+      nodeLabelName: node-cronjobs
+      nodeLabelOS: amd64
     containers:
       generic-container:
         containerContext: generic-context


### PR DESCRIPTION
## Purpose of PR
[Allows you to pin deployments to certain nodes based on nodeSelector labels](https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes/#create-a-pod-that-gets-scheduled-to-your-chosen-node).

Note: this **only** allows for pinning deployments using nodeSelectors. [Other deployment pinning techniques](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/) such as affinity, anti-affinity, nodename etc have not been implemented

## Parts of the app this will impact

## Todos
Test nodeSelector works for
- [x] deployments
- [x] jobs
- [x] cronjobs

Tests have been completed against a repo only maintainers can see, it is referenced below in the PR log.

## Additional information

## Related links