### PR TITLE
Use kube-context for kubetools config command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+- Fix bug where `config` command was not printing the actual `k8s` configs used by `deploy` because it did not take into account the kube-context, whether default or given with `--context`.
 
 # v13.13.0
 - Cython 3.0 release is preventing this package to be released. A constraint of `cython<3` needs to be added to install this

--- a/kubetools/cli/generate_config.py
+++ b/kubetools/cli/generate_config.py
@@ -53,7 +53,8 @@ def config(ctx, replicas, file, app_dir, output_format, default_registry):
     Generate and write out Kubernetes configs for a project.
     '''
 
-    kubetools_config = load_kubetools_config(app_dir, custom_config_file=file)
+    env = ctx.meta['kube_context']
+    kubetools_config = load_kubetools_config(app_dir, env=env, custom_config_file=file)
     context_to_image = defaultdict(lambda: 'IMAGE')
     services, deployments, jobs, cronjobs = generate_kubernetes_configs_for_project(
         kubetools_config,


### PR DESCRIPTION
This ensures that the generated config matches the configs used when using the corresponding deploy command
