### PR TITLE
use docker compose v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 # v14.0.0-dev
 - **DO NOT USE WITH DOCKER DESKTOP v4.27.[0..2]** as this has a bug using `insecure-registries` with `docker compose` - [issue here](https://github.com/docker/buildx/issues/2030)
+- this is a `dev` release because of this bug - there is a workaround for this but we don't want to use workarounds in production
 - this **BREAKS COMPATIBILITY** with previous versions of `ktd` (see README)
 - uses `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### Unreleased
 
-# v20.0.0
-- use `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
+# v14.0.0
+- this **BREAKS COMPATIBILITY** with previous versions of `ktd` (see README)
+- uses `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
 
 # v13.13.1
 - Add nodeSelector config to kubetools file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-# v14.0.0-dev
+# v14.0.0
 - before upgrading to version 14.0 or above, you _must_ run `ktd destroy` for all existing 
 local Kubetools projects.
 - this is a `dev` release because of a bug in `docker/buildx` - there is a workaround for this but we don't want to use workarounds in production (see TROUBLESHOOTING in README)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### Unreleased
 
 # v14.0.0-dev
-- **DO NOT USE WITH DOCKER DESKTOP v4.27.[0..2]** as this has a bug using `insecure-registries` with `docker compose` - [issue here](https://github.com/docker/buildx/issues/2030)
-- this is a `dev` release because of this bug - there is a workaround for this but we don't want to use workarounds in production
+- before upgrading to version 14.0 or above, you _must_ run `ktd destroy` for all existing 
+local Kubetools projects.
+- this is a `dev` release because of a bug in `docker/buildx` - there is a workaround for this but we don't want to use workarounds in production (see TROUBLESHOOTING in README)
 - this **BREAKS COMPATIBILITY** with previous versions of `ktd` (see README)
 - uses `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-# v14.0.0
+# v14.0.0-dev
 - **DO NOT USE WITH DOCKER DESKTOP v4.27.[0..2]** as this has a bug using `insecure-registries` with `docker compose` - [issue here](https://github.com/docker/buildx/issues/2030)
 - this **BREAKS COMPATIBILITY** with previous versions of `ktd` (see README)
 - uses `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 # v14.0.0
+- **DO NOT USE WITH DOCKER DESKTOP v4.27.[0..2]** as this has a bug using `insecure-registries` with `docker compose` - [issue here](https://github.com/docker/buildx/issues/2030)
 - this **BREAKS COMPATIBILITY** with previous versions of `ktd` (see README)
 - uses `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v20.0.0
+- use `docker compose` in place of `docker-compose`, meaning we use Docker compose v2 on the backend
+
 # v13.13.1
 - Add nodeSelector config to kubetools file
 - Fix bug where `config` command was not printing the actual `k8s` configs used by `deploy` because it did not take into account the kube-context, whether default or given with `--context`.

--- a/README.md
+++ b/README.md
@@ -85,11 +85,13 @@ ktd up
 ```
 
 **NOTE**: there is a bug in the Docker BuildKit that ignores "insecure-registries". 
-as `docker compose` V2 uses BuildKit by default, the only way to currently get around this 
+As `docker compose` V2 uses BuildKit by default, the only way to currently get around this 
 is to append `DOCKER_BUILDKIT=0` in front of the `ktd` command,
+
 e.g: `DOCKER_BUILDKIT=0 ktd up`.
+
 This applies to all `Dockerfile`s where an insecure registry is specified.
- 
+
 ```sh
 # Deploy the project to a Kubernetes namespace
 kubetools deploy my-namespace

--- a/README.md
+++ b/README.md
@@ -82,12 +82,23 @@ With this in your current directory, you can now:
 ```sh
 # Bring up a local development environment using docker compose
 ktd up
+```
 
+**NOTE**: there is a bug in the Docker BuildKit that ignores "insecure-registries". 
+as `docker compose` V2 uses BuildKit by default, the only way to currently get around this 
+is to append `DOCKER_BUILDKIT=0` in front of the `ktd` command,
+e.g: `DOCKER_BUILDKIT=0 ktd up`.
+This applies to all `Dockerfile`s where an insecure registry is specified.
+ 
+```sh
 # Deploy the project to a Kubernetes namespace
 kubetools deploy my-namespace
 ```
 
 ## Installing
+
+**NOTE**: before upgrading to version 14.0 or above, you _must_ run `ktd destroy` for all existing 
+local Kubetools projects.
 
 ```sh
 pip install kubetools

--- a/README.md
+++ b/README.md
@@ -84,14 +84,6 @@ With this in your current directory, you can now:
 ktd up
 ```
 
-**NOTE**: there is a bug in the Docker BuildKit that ignores "insecure-registries". 
-As `docker compose` V2 uses BuildKit by default, the only way to currently get around this 
-is to append `DOCKER_BUILDKIT=0` in front of the `ktd` command,
-
-e.g: `DOCKER_BUILDKIT=0 ktd up`.
-
-This applies to all `Dockerfile`s where an insecure registry is specified.
-
 ```sh
 # Deploy the project to a Kubernetes namespace
 kubetools deploy my-namespace
@@ -101,7 +93,14 @@ kubetools deploy my-namespace
 
 **NOTE**: before upgrading to version 14.0 or above, you _must_ run `ktd destroy` for all existing 
 local Kubetools projects.
+There is also a bug on the latest version of Docker Desktop that prevents the new Buildkit working with 
+insecure registries. This has been patched but the patch has yet to make its way to the latest release
+of Docker Desktop - [issue here](https://github.com/docker/buildx/issues/2030). 
+There are a couple of workarounds:
+  *  Downgrade to Docker Desktop v4.26.0 or below and append `http://` to each of your `insecure_registries`' URLs
+  *  Alternatively, use the legacy builder by appending `DOCKER_BUILDKIT=0` in front of every `ktd` command.
 
+To install Kubetools run:
 ```sh
 pip install kubetools
 ```

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ There is also a bug on the latest version of Docker Desktop that prevents the ne
 insecure registries. This has been patched but the patch has yet to make its way to the latest release
 of Docker Desktop - [issue here](https://github.com/docker/buildx/issues/2030). 
 There are a couple of workarounds:
-  *  Downgrade to Docker Desktop v4.26.0 or below and append `http://` to each of your `insecure_registries`' URLs
-  *  Alternatively, use the legacy builder by appending `DOCKER_BUILDKIT=0` in front of every `ktd` command.
+  * Migrate to secure registries (over HTTPS)
+  * Downgrade to Docker Desktop v4.26.0 or below and prefix with `http://`, each of your `insecure_registries`' URLs.
+  *  Alternatively, use the legacy builder by setting the environment variable `DOCKER_BUILDKIT=0` for `ktd` commands.
 
 To install Kubetools run:
 ```sh

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ And you would like:
 
 Kubetools provides the tooling required to achieve this, by way of two CLI tools:
 
-+ **`ktd`**: generates _100% local_ development environments using Docker/docker-compose
++ **`ktd`**: generates _100% local_ development environments using docker compose
 + **`kubetools`**: deploys projects to Kubernetes, handling any changes/jobs as required
 
 Both of these use a single configuration file, `kubetools.yml`, for example a basic `django` app:
@@ -80,7 +80,7 @@ cronjobs:
 With this in your current directory, you can now:
 
 ```sh
-# Bring up a local development environment using docker-compose
+# Bring up a local development environment using docker compose
 ktd up
 
 # Deploy the project to a Kubernetes namespace

--- a/README.md
+++ b/README.md
@@ -90,17 +90,6 @@ kubetools deploy my-namespace
 ```
 
 ## Installing
-
-**NOTE**: before upgrading to version 14.0 or above, you _must_ run `ktd destroy` for all existing 
-local Kubetools projects.
-There is also a bug on the latest version of Docker Desktop that prevents the new Buildkit working with 
-insecure registries. This has been patched but the patch has yet to make its way to the latest release
-of Docker Desktop - [issue here](https://github.com/docker/buildx/issues/2030). 
-There are a couple of workarounds:
-  * Migrate to secure registries (over HTTPS)
-  * Downgrade to Docker Desktop v4.26.0 or below and prefix with `http://`, each of your `insecure_registries`' URLs.
-  *  Alternatively, use the legacy builder by setting the environment variable `DOCKER_BUILDKIT=0` for `ktd` commands.
-
 To install Kubetools run:
 ```sh
 pip install kubetools
@@ -149,6 +138,23 @@ MINIKUBE_IP=$(minikube ip)
 minikube delete
 ...
 ```
+
+
+## Troubleshooting
+There is a bug in `buildx` which is present in Docker Engine v25.0 and up, which is yet to be patched and causes `insecure-registries` to be ignored - [issue here](https://github.com/docker/buildx/issues/2226).
+Versions of Docker Desktop which use versions of Docker Engine lower than 25.0 are unaffected.
+
+If you try and run `ktd up` with reference to an unsecure registry, e.g. `http://docker-registry.example.net` and are affected by this bug, you will get an error message that is
+similar to the following:
+```
+ERROR: failed to do request: Head "https://docker-registry.example.net/3.6_alpine3.13_v0.1-multi": dialing docker-registry.example.net:443 with direct connection: connecting to 1.1.1.1:443: dial tcp 1.1.1.1:443: connect: connection refused
+```
+
+There are a few of workarounds:
+  * Migrate to secure registries (over HTTPS)
+  * Downgrade to Docker Desktop v4.26.1 or below and prefix `http://` to each of your `insecure_registries`' URLs.
+  *  Alternatively, use the legacy builder by setting the environment variable `DOCKER_BUILDKIT=0` for `ktd` commands.
+
 
 ## Releasing (admins/maintainers only)
 * Update [CHANGELOG](CHANGELOG.md) to add new version and document it

--- a/kubetools/dev/backends/docker_compose/config.py
+++ b/kubetools/dev/backends/docker_compose/config.py
@@ -248,9 +248,8 @@ def create_compose_config(kubetools_config):
     if dev_network:
         compose_config['networks'] = {
             'default': {
-                'external': {
-                    'name': 'dev',
-                },
+                'name': 'dev',
+                'external': True,
             },
         }
 

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -136,8 +136,10 @@ def get_containers_status(
         if not env:
             env = compose_project.replace(docker_name, '')
 
-        # Where the name is compose-name_container_N, get container
-        name = container.name.split('-')[1]
+        # if the container was made in v1, it will be compose_name_container_N
+        converted_name = container.name.replace('_', '-')
+        # if the container is called compose-name-container-N, get `container`
+        name = converted_name.split('-')[1]
 
         status = container.status == 'running'
         ports = []

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -136,10 +136,14 @@ def get_containers_status(
         if not env:
             env = compose_project.replace(docker_name, '')
 
-        # if the container was made in v1, it will be compose_name_container_N
+        # if the container was made in v1, it will be composename_container_N
         converted_name = container.name.replace('_', '-')
-        # if the container is called compose-name-container-N, get `container`
-        name = converted_name.split('-')[1]
+
+        # we need to keep the middle part of the name
+        # for example if we have a container called `composename-container-1-N`
+        # we want to keep `container-1`
+        middle_names = converted_name.split('-')[1:-1]
+        name = '-'.join(middle_name for middle_name in middle_names)
 
         status = container.status == 'running'
         ports = []

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -136,14 +136,7 @@ def get_containers_status(
         if not env:
             env = compose_project.replace(docker_name, '')
 
-        # if the container was made in v1, it will be composename_container_N
-        converted_name = container.name.replace('_', '-')
-
-        # we need to keep the middle part of the name
-        # for example if we have a container called `composename-container-1-N`
-        # we want to keep `container-1`
-        middle_names = converted_name.split('-')[1:-1]
-        name = '-'.join(middle_name for middle_name in middle_names)
+        name = _get_container_name_from_full_name(container.name)
 
         status = container.status == 'running'
         ports = []
@@ -196,6 +189,17 @@ def get_containers_status(
     if all_environments:
         return env_to_containers
     return env_to_containers.get(kubetools_config['env'], {})
+
+
+def _get_container_name_from_full_name(full_name):
+    # if the container was made in v1, it will be composename_container_N
+    converted_name = full_name.replace('_', '-')
+
+    # we need to keep the middle part of the name
+    # for example if we have a container called `composename-container-1-N`
+    # we want to keep `container-1`
+    middle_names = converted_name.split('-')[1:-1]
+    return '-'.join(middle_name for middle_name in middle_names)
 
 
 def get_container_status(kubetools_config, name):

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -6,6 +6,7 @@ import requests
 from kubetools.dev.process_util import run_process
 from kubetools.exceptions import KubeDevError
 from kubetools.log import logger
+from kubetools import __version__
 
 from .config import (
     create_compose_config,
@@ -137,7 +138,13 @@ def get_containers_status(
             env = compose_project.replace(docker_name, '')
 
         # Where the name is compose-name_container_N, get container
-        name = container.name.split('_')[1]
+        print(container.name)
+        print(container.labels.get('kubetools.project.env'))
+        if int(__version__.split('.')[0]) < 20:
+            name = container.name.split('_')[1]
+        else:
+            name = container.name.split('-')[1]
+
 
         status = container.status == 'running'
         ports = []
@@ -202,7 +209,7 @@ def run_compose_process(kubetools_config, command_args, **kwargs):
     create_compose_config(kubetools_config)
 
     compose_command = [
-        'docker-compose',
+        'docker', 'compose',
         # Force us to look at the current directory, not relative to the compose
         # filename (ie .kubetools/compose-name.yml).
         '--project-directory', '.',

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -1,5 +1,3 @@
-import sys
-
 from functools import lru_cache
 
 import docker

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -3,10 +3,10 @@ from functools import lru_cache
 import docker
 import requests
 
+from kubetools import __version__
 from kubetools.dev.process_util import run_process
 from kubetools.exceptions import KubeDevError
 from kubetools.log import logger
-from kubetools import __version__
 
 from .config import (
     create_compose_config,
@@ -144,7 +144,6 @@ def get_containers_status(
             name = container.name.split('_')[1]
         else:
             name = container.name.split('-')[1]
-
 
         status = container.status == 'running'
         ports = []

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -3,7 +3,6 @@ from functools import lru_cache
 import docker
 import requests
 
-from kubetools import __version__
 from kubetools.dev.process_util import run_process
 from kubetools.exceptions import KubeDevError
 from kubetools.log import logger
@@ -138,12 +137,7 @@ def get_containers_status(
             env = compose_project.replace(docker_name, '')
 
         # Where the name is compose-name_container_N, get container
-        print(container.name)
-        print(container.labels.get('kubetools.project.env'))
-        if int(__version__.split('.')[0]) < 20:
-            name = container.name.split('_')[1]
-        else:
-            name = container.name.split('-')[1]
+        name = container.name.split('-')[1]
 
         status = container.status == 'running'
         ports = []

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,6 @@ if __name__ == '__main__':
             # To support CronJob api versions 'batch/v1beta1' & 'batch/v1'
             'kubernetes>=21.7.0,<25.0.0',
             'tabulate<1',
-            # compose v2 has broken container naming
-            'docker-compose<2',
         ),
         extras_require={
             'dev': (

--- a/tests/configs/complex_named_app/k8s_cronjobs.yml
+++ b/tests/configs/complex_named_app/k8s_cronjobs.yml
@@ -3,7 +3,7 @@ metadata:
   name: generic-cronjob
   labels: {
     kubetools/name: generic-cronjob,
-    kubetools/project_name: generic-app,
+    kubetools/project_name: complex-named-app,
     kubetools/role: cronjob
   }
   annotations: {
@@ -21,7 +21,7 @@ spec:
           name: generic-cronjob
           labels: {
             kubetools/name: generic-cronjob,
-            kubetools/project_name: generic-app,
+            kubetools/project_name: complex-named-app,
             kubetools/role: cronjob
           }
           annotations: {

--- a/tests/configs/complex_named_app/k8s_cronjobs.yml
+++ b/tests/configs/complex_named_app/k8s_cronjobs.yml
@@ -1,0 +1,40 @@
+kind: CronJob
+metadata:
+  name: generic-cronjob
+  labels: {
+    kubetools/name: generic-cronjob,
+    kubetools/project_name: generic-app,
+    kubetools/role: cronjob
+  }
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    description: 'Run: [''generic-command'']'
+  }
+spec:
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 10
+  concurrencyPolicy: "Allow"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: generic-cronjob
+          labels: {
+            kubetools/name: generic-cronjob,
+            kubetools/project_name: generic-app,
+            kubetools/role: cronjob
+          }
+          annotations: {
+            app.kubernetes.io/managed-by: kubetools,
+            description: 'Run: [''generic-command'']'
+          }
+        spec:
+          containers:
+          - command: [generic-command]
+            containerContext: generic-context
+            env:
+            - {name: KUBE, value: 'true'}
+            image: generic-image
+            imagePullPolicy: 'Always'
+            name: generic-container
+          restartPolicy: OnFailure

--- a/tests/configs/complex_named_app/k8s_deployments.yml
+++ b/tests/configs/complex_named_app/k8s_deployments.yml
@@ -24,7 +24,7 @@ spec:
         livenessProbe:
           httpGet: {path: /ping, port: 80}
           timeoutSeconds: 5
-        name: webserver
+        name: complex-webserver
         readinessProbe:
           httpGet: {path: /ping, port: 80}
           timeoutSeconds: 5

--- a/tests/configs/complex_named_app/k8s_deployments.yml
+++ b/tests/configs/complex_named_app/k8s_deployments.yml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: complex-named-app, kubetools/project_name: complex-named-app, kubetools/role: app}
+  name: complex-named-app
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: complex-named-app, kubetools/project_name: complex-named-app,
+      kubetools/role: app}
+  template:
+    metadata:
+      labels: {kubetools/name: complex-named-app, kubetools/project_name: complex-named-app, kubetools/role: app}
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5
+        name: webserver
+        readinessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5

--- a/tests/configs/complex_named_app/k8s_jobs.yml
+++ b/tests/configs/complex_named_app/k8s_jobs.yml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools, description: 'Run: [''generic-command'']'}
+  labels: {job-id: UUID, kubetools/project_name: complex-named-app,
+    kubetools/role: job}
+  name: UUID
+spec:
+  completions: 1
+  parallelism: 1
+  selector: {job-id: UUID, kubetools/project_name: complex-named-app,
+    kubetools/role: job}
+  template:
+    metadata:
+      labels: {job-id: UUID, kubetools/project_name: complex-named-app,
+        kubetools/role: job}
+    spec:
+      containers:
+      - chdir: /
+        command: [generic-command]
+        env:
+        - {name: KUBE, value: 'true'}
+        - {name: KUBE_JOB_ID, value: UUID}
+        image: generic-image
+        imagePullPolicy: Always
+        name: upgrade
+        resources:
+          requests:
+            memory: "1Gi"
+      restartPolicy: Never

--- a/tests/configs/complex_named_app/k8s_services.yml
+++ b/tests/configs/complex_named_app/k8s_services.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {kubetools/name: complex-named-app, kubetools/project_name: complex-named-app, kubetools/role: app}
+  name: complex-named-app
+spec:
+  ports:
+  - {port: 80, targetPort: 80}
+  selector: {kubetools/name: complex-named-app, kubetools/project_name: complex-named-app, kubetools/role: app}
+  type: NodePort

--- a/tests/configs/complex_named_app/kubetools.yml
+++ b/tests/configs/complex_named_app/kubetools.yml
@@ -1,0 +1,38 @@
+name: complex-named-app
+
+
+containerContexts:
+  generic-context:
+    image: generic-image
+    command: [generic-command]
+    ports:
+      - 80
+
+upgrades:
+  - name: Upgrade the database
+    containerContext: generic-context
+    command: [generic-command, generic-arg]
+    resources:
+      requests:
+        memory: "1Gi"
+
+
+deployments:
+  complex-named-app:
+    containers:
+      complex-webserver:
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        containerContext: generic-context
+        probes:
+          timeoutSeconds: 5
+          httpGet:
+            path: /ping
+
+
+cronjobs:
+  generic-cronjob:
+    schedule: "*/1 * * * *"
+    concurrency_policy: "Allow"
+    containers:
+      generic-container:
+        containerContext: generic-context

--- a/tests/test_config_generation.py
+++ b/tests/test_config_generation.py
@@ -13,6 +13,9 @@ class TestKubernetesConfigGeneration(TestCase):
     def test_basic_app_configs(self):
         _test_configs('basic_app')
 
+    def test_complex_named_app_configs(self):
+        _test_configs('complex_named_app')
+
     def test_dependencies_configs(self):
         _test_configs('dependencies')
 

--- a/tests/test_docker_util.py
+++ b/tests/test_docker_util.py
@@ -1,0 +1,37 @@
+from string import ascii_lowercase
+from unittest import TestCase
+
+from kubetools.dev.backends.docker_compose.config import dockerise_label
+from kubetools.dev.backends.docker_compose.docker_util import _get_container_name_from_full_name
+
+
+def generate_long_names(number_of_separators, separator):
+    return separator.join([
+        ch for ch in ascii_lowercase[:number_of_separators+1]])
+
+
+class TestDockerComposeNameConversion(TestCase):
+    # we need to check this works for dashes and underscores
+    def test_dockerise_label_dashes(self):
+        for i in range(5):
+            long_name = generate_long_names(i, '-')
+            dockerised_name = dockerise_label(long_name)
+            self.assertEqual(dockerised_name, ascii_lowercase[:i+1])
+
+    def test_dockerise_label_underscores(self):
+        for i in range(5):
+            long_name = generate_long_names(i, '_')
+            dockerised_name = dockerise_label(long_name)
+            self.assertEqual(dockerised_name, ascii_lowercase[:i+1])
+
+    def test_container_name_from_full_name_dashes(self):
+        for i in range(5):
+            container_name = generate_long_names(i, '-')
+            full_name = '-'.join([ascii_lowercase[:i+1], container_name, '1'])
+            self.assertEqual(_get_container_name_from_full_name(full_name), container_name)
+
+    def test_container_name_from_full_name_underscores(self):
+        for i in range(5):
+            container_name = generate_long_names(i, '-')
+            full_name = '_'.join([ascii_lowercase[:i+1], container_name, '1'])
+            self.assertEqual(_get_container_name_from_full_name(full_name), container_name)


### PR DESCRIPTION
docker compose v2 is part of Docker nowadays. Rather than calling a separate Python lib that calls `docker-compose`, call `docker compose` and use v2.
Fix the `-` and `_` difference between v1 and v2.
This will need THOROUGH testing

PFM-827

## Purpose of PR
Upgrade to use Docker Compose V2
## Parts of the app this will impact
docker compose
## Todos
Test on Linux machines, different CI builds with different packages
## Additional information
This will require Docker with Compose v2
## Related links