### PR TITLE
Use python docker compose

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -6,9 +6,9 @@ jobs:
   publish-to-pypi:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install build dependencies

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -14,9 +14,9 @@ jobs:
             python-version: '3.6'
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       # See https://github.com/yaml/pyyaml/issues/601

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         exclude:
           # Python 3.6 is not available in GitHub Actions Ubuntu 22.04
           - os: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Install package
         run: PIP_CONSTRAINT=/tmp/constraint.txt python -m pip install .[dev]
       - name: Linting
+        # Python 3.12 bug breaks flake8: https://github.com/PyCQA/flake8/issues/1905
+        if: matrix.python-version != '3.12'
         run: "flake8"
       - name: Unit tests
         run: "pytest --cov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Unreleased
 
+# v13.14.0
+- Fix docker-compose conflict when kubetools commands are called without activating their venv
+- Add Python 3.12 to supported versions, albeit without Flake8 because of CPython bug
+- Upgrade GitHub actions workflow to deal with deprecation warnings
+
 # v13.13.1
 - Add nodeSelector config to kubetools file
 - Fix bug where `config` command was not printing the actual `k8s` configs used by `deploy` because it did not take into account the kube-context, whether default or given with `--context`.

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -1,3 +1,5 @@
+import sys
+
 from functools import lru_cache
 
 import docker
@@ -202,7 +204,8 @@ def run_compose_process(kubetools_config, command_args, **kwargs):
     create_compose_config(kubetools_config)
 
     compose_command = [
-        'docker-compose',
+        # Use current interpreter to run the docker-compose module installed in the same venv
+        sys.executable, '-m', 'compose',
         # Force us to look at the current directory, not relative to the compose
         # filename (ie .kubetools/compose-name.yml).
         '--project-directory', '.',

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11',
+            'Programming Language :: Python :: 3.12',
             'Topic :: Software Development :: Build Tools',
             'Topic :: Software Development :: Testing',
             'Topic :: System :: Software Distribution',


### PR DESCRIPTION
## Purpose of PR
When `ktd` is invoked, it used to call `docker-compose` command from the current PATH. This causes conflict with newer versions of docker which install their own version of `docker-compose` in the PATH. The version from Docker is using the "Compose V2" standard which is not yet supported by `kubetools` (WIP: #163).

This change makes sure that we call the "python" version of `docker-compose`. By using the current "executable", i.e. the current interpreter which is running `ktd`, and calling `compose` as a Python module, we maximise the chances that the version of docker-compose used is the Python one that was installed as a dependency of `kubetools`.

This creates the opportunity to install `kubetools` in its own separate virtualenv and run it by linking `kubetools` and `ktd` executables into the PATH. In a similar fashion, this should allow the support of `pipx` as an installation method.