### PR TITLE
PFM-1685 / Add annotations option to resources defined in kubetools.yaml file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+# v13.14.1
+- Add annotations option to resources defined in kubetools.yaml file
+
 # v13.14.0
 - Fix docker-compose conflict when kubetools commands are called without activating their venv
 - Add Python 3.12 to supported versions, albeit without Flake8 because of CPython bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Unreleased
 
 # v13.14.1
-- Add annotations option to resources defined in kubetools.yaml file
+- Add annotations and labels options to resources defined in kubetools.yaml file
 
 # v13.14.0
 - Fix docker-compose conflict when kubetools commands are called without activating their venv

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ tests:
 
 deployments:
   my-app-webserver:
+    annotations:
+      imageregistry: "https://hub.docker.com/"
+    labels:
+      app.kubernetes.io/name: my-app-webserver
     serviceAccountName: webserver
     secrets:
       secret-volume:
@@ -59,8 +63,6 @@ deployments:
           - 80
         dev:
           command: [./manage.py, runserver, '0.0.0.0:80']
-        annotations:
-          imageregistry: "https://hub.docker.com/"
 
 dependencies:
   mariadb:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ deployments:
           - 80
         dev:
           command: [./manage.py, runserver, '0.0.0.0:80']
+        annotations:
+          app.kubernetes.io/name: "django_app"
 
 dependencies:
   mariadb:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ deployments:
         dev:
           command: [./manage.py, runserver, '0.0.0.0:80']
         annotations:
-          app.kubernetes.io/name: "django_app"
+          imageregistry: "https://hub.docker.com/"
 
 dependencies:
   mariadb:

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -183,8 +183,7 @@ def generate_kubernetes_configs_for_project(
         )
         app_annotations = copy_and_update(base_annotations)
         for container_name, data in containers.items():
-            if data.get('annotations'):
-                app_annotations.update(data.get('annotations'))
+            app_annotations.update(data.get('annotations', {}))
 
         if container_ports:
             services.append(make_service_config(
@@ -230,8 +229,7 @@ def generate_kubernetes_configs_for_project(
             per_deployment_annotations.get(name),
         )
         for container_name, data in containers.items():
-            if data.get('annotations'):
-                app_annotations.update(data.get('annotations'))
+            app_annotations.update(data.get('annotations', {}))
 
         if container_ports:
             services.append(make_service_config(
@@ -333,8 +331,8 @@ def generate_kubernetes_configs_for_project(
 
         app_annotations = copy_and_update(base_annotations)
         for container_name, data in containers.items():
-            if data.get('annotations'):
-                app_annotations.update(data.get('annotations'))
+            app_annotations.update(data.get('annotations', {}))
+
         schedule = cronjob['schedule']
         concurrency_policy = cronjob['concurrency_policy']
         batch_api_version = cronjob.get('batch-api-version')  # May depend on target cluster

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -166,10 +166,14 @@ def generate_kubernetes_configs_for_project(
 
     for name, dependency in config.get('dependencies', {}).items():
         dependency_name = make_deployment_name(project_name, name)
-        dependency_labels = copy_and_update(base_labels, {
-            ROLE_LABEL_KEY: 'dependency',
-            NAME_LABEL_KEY: dependency_name,
-        })
+        dependency_labels = copy_and_update(
+            base_labels,
+            {
+                ROLE_LABEL_KEY: 'dependency',
+                NAME_LABEL_KEY: dependency_name,
+            },
+            dependency.get('labels', {}),
+        )
 
         node_selector_labels = dependency.get('nodeSelector', None)
         service_account_name = dependency.get('serviceAccountName', None)
@@ -210,10 +214,14 @@ def generate_kubernetes_configs_for_project(
 
     for name, deployment in config.get('deployments', {}).items():
         deployment_name = make_deployment_name(project_name, name)
-        deployment_labels = copy_and_update(base_labels, {
-            ROLE_LABEL_KEY: 'app',
-            NAME_LABEL_KEY: deployment_name,
-        })
+        deployment_labels = copy_and_update(
+            base_labels,
+            {
+                ROLE_LABEL_KEY: 'app',
+                NAME_LABEL_KEY: deployment_name,
+            },
+            deployment.get('labels', {}),
+        )
 
         node_selector_labels = deployment.get('nodeSelector', None)
         service_account_name = deployment.get('serviceAccountName', None)
@@ -317,10 +325,14 @@ def generate_kubernetes_configs_for_project(
     cronjobs = []
 
     for name, cronjob in config.get('cronjobs', {}).items():
-        cronjob_labels = copy_and_update(base_labels, {
-            ROLE_LABEL_KEY: 'cronjob',
-            NAME_LABEL_KEY: name,
-        })
+        cronjob_labels = copy_and_update(
+            base_labels,
+            {
+                ROLE_LABEL_KEY: 'cronjob',
+                NAME_LABEL_KEY: name,
+            },
+            cronjob.get('labels', {}),
+        )
 
         node_selector_labels = cronjob.get('nodeSelector', None)
         service_account_name = cronjob.get('serviceAccountName', None)

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -182,6 +182,8 @@ def generate_kubernetes_configs_for_project(
             default_registry=default_registry,
         )
         app_annotations = copy_and_update(base_annotations)
+        for container_name, data in containers.items():
+            app_annotations = copy_and_update(data.get('annotations'))
 
         if container_ports:
             services.append(make_service_config(
@@ -226,6 +228,8 @@ def generate_kubernetes_configs_for_project(
             base_annotations,
             per_deployment_annotations.get(name),
         )
+        for container_name, data in containers.items():
+            app_annotations = copy_and_update(data.get('annotations'))
 
         if container_ports:
             services.append(make_service_config(
@@ -326,6 +330,8 @@ def generate_kubernetes_configs_for_project(
         )
 
         app_annotations = copy_and_update(base_annotations)
+        for container_name, data in containers.items():
+            app_annotations = copy_and_update(data.get('annotations'))
         schedule = cronjob['schedule']
         concurrency_policy = cronjob['concurrency_policy']
         batch_api_version = cronjob.get('batch-api-version')  # May depend on target cluster

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -183,7 +183,8 @@ def generate_kubernetes_configs_for_project(
         )
         app_annotations = copy_and_update(base_annotations)
         for container_name, data in containers.items():
-            app_annotations = copy_and_update(data.get('annotations'))
+            if data.get('annotations'):
+                app_annotations.update(data.get('annotations'))
 
         if container_ports:
             services.append(make_service_config(
@@ -229,7 +230,8 @@ def generate_kubernetes_configs_for_project(
             per_deployment_annotations.get(name),
         )
         for container_name, data in containers.items():
-            app_annotations = copy_and_update(data.get('annotations'))
+            if data.get('annotations'):
+                app_annotations.update(data.get('annotations'))
 
         if container_ports:
             services.append(make_service_config(
@@ -331,7 +333,8 @@ def generate_kubernetes_configs_for_project(
 
         app_annotations = copy_and_update(base_annotations)
         for container_name, data in containers.items():
-            app_annotations = copy_and_update(data.get('annotations'))
+            if data.get('annotations'):
+                app_annotations.update(data.get('annotations'))
         schedule = cronjob['schedule']
         concurrency_policy = cronjob['concurrency_policy']
         batch_api_version = cronjob.get('batch-api-version')  # May depend on target cluster

--- a/kubetools/kubernetes/config/__init__.py
+++ b/kubetools/kubernetes/config/__init__.py
@@ -181,9 +181,10 @@ def generate_kubernetes_configs_for_project(
             deployment_name=name,
             default_registry=default_registry,
         )
-        app_annotations = copy_and_update(base_annotations)
-        for container_name, data in containers.items():
-            app_annotations.update(data.get('annotations', {}))
+        app_annotations = copy_and_update(
+            base_annotations,
+            dependency.get('annotations', {}),
+        )
 
         if container_ports:
             services.append(make_service_config(
@@ -227,9 +228,8 @@ def generate_kubernetes_configs_for_project(
         app_annotations = copy_and_update(
             base_annotations,
             per_deployment_annotations.get(name),
+            deployment.get('annotations', {}),
         )
-        for container_name, data in containers.items():
-            app_annotations.update(data.get('annotations', {}))
 
         if container_ports:
             services.append(make_service_config(
@@ -298,12 +298,16 @@ def generate_kubernetes_configs_for_project(
         node_selector_labels = job_spec.get('nodeSelector', None)
         service_account_name = job_spec.get('serviceAccountName', None)
         secrets = job_spec.get('secrets', None)
+        app_annotations = copy_and_update(
+            base_annotations,
+            job_spec.get('annotations', {}),
+        )
 
         jobs.append(make_job_config(
             job_spec,
             app_name=project_name,
             labels=job_labels,
-            annotations=base_annotations,
+            annotations=app_annotations,
             envvars=job_envvars,
             node_selector_labels=node_selector_labels,
             service_account_name=service_account_name,
@@ -329,9 +333,10 @@ def generate_kubernetes_configs_for_project(
             default_registry=default_registry,
         )
 
-        app_annotations = copy_and_update(base_annotations)
-        for container_name, data in containers.items():
-            app_annotations.update(data.get('annotations', {}))
+        app_annotations = copy_and_update(
+            base_annotations,
+            cronjob.get('annotations', {}),
+        )
 
         schedule = cronjob['schedule']
         concurrency_policy = cronjob['concurrency_policy']

--- a/kubetools/kubernetes/config/container.py
+++ b/kubetools/kubernetes/config/container.py
@@ -128,6 +128,9 @@ def make_container_config(
                 'readonly': True,
             })
 
+    # Remove annotations from container data
+    if 'annotations' in container:
+        container.pop('annotations')
     # Finally, attach all remaining data
     container_data.update(container)
 

--- a/kubetools/kubernetes/config/container.py
+++ b/kubetools/kubernetes/config/container.py
@@ -128,9 +128,6 @@ def make_container_config(
                 'readonly': True,
             })
 
-    # Remove annotations from container data
-    if 'annotations' in container:
-        container.pop('annotations')
     # Finally, attach all remaining data
     container_data.update(container)
 

--- a/tests/configs/basic_app/k8s_cronjobs.yml
+++ b/tests/configs/basic_app/k8s_cronjobs.yml
@@ -83,3 +83,48 @@ spec:
             imagePullPolicy: 'Always'
             name: generic-container
           restartPolicy: OnFailure
+
+---
+
+kind: CronJob
+metadata:
+  name: generic-cronjob-with-labels
+  labels: {
+    app.kubernetes.io/name: generic-cronjob-with-labels,
+    kubetools/name: generic-cronjob-with-labels,
+    kubetools/project_name: generic-app,
+    kubetools/role: cronjob
+  }
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    description: 'Run: [''generic-command'']'
+  }
+spec:
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 10
+  concurrencyPolicy: "Allow"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: generic-cronjob-with-labels
+          labels: {
+            app.kubernetes.io/name: generic-cronjob-with-labels,
+            kubetools/name: generic-cronjob-with-labels,
+            kubetools/project_name: generic-app,
+            kubetools/role: cronjob,
+          }
+          annotations: {
+            app.kubernetes.io/managed-by: kubetools,
+            description: 'Run: [''generic-command'']'
+          }
+        spec:
+          containers:
+          - command: [generic-command]
+            containerContext: generic-context
+            env:
+            - {name: KUBE, value: 'true'}
+            image: generic-image
+            imagePullPolicy: 'Always'
+            name: generic-container
+          restartPolicy: OnFailure

--- a/tests/configs/basic_app/k8s_cronjobs.yml
+++ b/tests/configs/basic_app/k8s_cronjobs.yml
@@ -38,3 +38,48 @@ spec:
             imagePullPolicy: 'Always'
             name: generic-container
           restartPolicy: OnFailure
+
+---
+
+kind: CronJob
+metadata:
+  name: generic-cronjob-with-annotations
+  labels: {
+    kubetools/name: generic-cronjob-with-annotations,
+    kubetools/project_name: generic-app,
+    kubetools/role: cronjob
+  }
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    app.kubernetes.io/name: generic-cronjob-with-annotations,
+    description: 'Run: [''generic-command'']'
+  }
+spec:
+  schedule: "*/1 * * * *"
+  startingDeadlineSeconds: 10
+  concurrencyPolicy: "Allow"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: generic-cronjob-with-annotations
+          labels: {
+            kubetools/name: generic-cronjob-with-annotations,
+            kubetools/project_name: generic-app,
+            kubetools/role: cronjob,
+          }
+          annotations: {
+            app.kubernetes.io/managed-by: kubetools,
+            app.kubernetes.io/name: generic-cronjob-with-annotations,
+            description: 'Run: [''generic-command'']'
+          }
+        spec:
+          containers:
+          - command: [generic-command]
+            containerContext: generic-context
+            env:
+            - {name: KUBE, value: 'true'}
+            image: generic-image
+            imagePullPolicy: 'Always'
+            name: generic-container
+          restartPolicy: OnFailure

--- a/tests/configs/basic_app/k8s_cronjobs.yml
+++ b/tests/configs/basic_app/k8s_cronjobs.yml
@@ -51,7 +51,7 @@ metadata:
   }
   annotations: {
     app.kubernetes.io/managed-by: kubetools,
-    app.kubernetes.io/name: generic-cronjob-with-annotations,
+    imageregistry: https://hub.docker.com/,
     description: 'Run: [''generic-command'']'
   }
 spec:
@@ -70,7 +70,7 @@ spec:
           }
           annotations: {
             app.kubernetes.io/managed-by: kubetools,
-            app.kubernetes.io/name: generic-cronjob-with-annotations,
+            imageregistry: https://hub.docker.com/,
             description: 'Run: [''generic-command'']'
           }
         spec:

--- a/tests/configs/basic_app/k8s_deployments.yml
+++ b/tests/configs/basic_app/k8s_deployments.yml
@@ -28,3 +28,50 @@ spec:
         readinessProbe:
           httpGet: {path: /ping, port: 80}
           timeoutSeconds: 5
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    app.kubernetes.io/name: generic-app-with-annotations
+  }
+  labels: {
+    kubetools/name: generic-app-with-annotations,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  name: generic-app-with-annotations
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {
+      kubetools/name: generic-app-with-annotations,
+      kubetools/project_name: generic-app,
+      kubetools/role: app
+    }
+  template:
+    metadata:
+      labels: {
+        kubetools/name: generic-app-with-annotations,
+        kubetools/project_name: generic-app,
+        kubetools/role: app
+      }
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5
+        name: webserver
+        readinessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5

--- a/tests/configs/basic_app/k8s_deployments.yml
+++ b/tests/configs/basic_app/k8s_deployments.yml
@@ -36,7 +36,7 @@ kind: Deployment
 metadata:
   annotations: {
     app.kubernetes.io/managed-by: kubetools,
-    app.kubernetes.io/name: generic-app-with-annotations
+    imageregistry: https://hub.docker.com/
   }
   labels: {
     kubetools/name: generic-app-with-annotations,

--- a/tests/configs/basic_app/k8s_deployments.yml
+++ b/tests/configs/basic_app/k8s_deployments.yml
@@ -75,3 +75,50 @@ spec:
         readinessProbe:
           httpGet: {path: /ping, port: 80}
           timeoutSeconds: 5
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {
+    app.kubernetes.io/name: generic-app-with-labels,
+    kubetools/name: generic-app-with-labels,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  name: generic-app-with-labels
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {
+      app.kubernetes.io/name: generic-app-with-labels,
+      kubetools/name: generic-app-with-labels,
+      kubetools/project_name: generic-app,
+      kubetools/role: app
+    }
+  template:
+    metadata:
+      labels: {
+        app.kubernetes.io/name: generic-app-with-labels,
+        kubetools/name: generic-app-with-labels,
+        kubetools/project_name: generic-app,
+        kubetools/role: app
+      }
+    spec:
+      containers:
+      - command: [generic-command]
+        containerContext: generic-context
+        env:
+        - {name: KUBE, value: 'true'}
+        image: generic-image
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5
+        name: webserver
+        readinessProbe:
+          httpGet: {path: /ping, port: 80}
+          timeoutSeconds: 5

--- a/tests/configs/basic_app/k8s_services.yml
+++ b/tests/configs/basic_app/k8s_services.yml
@@ -9,3 +9,28 @@ spec:
   - {port: 80, targetPort: 80}
   selector: {kubetools/name: generic-app, kubetools/project_name: generic-app, kubetools/role: app}
   type: NodePort
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    app.kubernetes.io/name: generic-app-with-annotations
+  }
+  labels: {
+    kubetools/name: generic-app-with-annotations,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  name: generic-app-with-annotations
+spec:
+  ports:
+  - {port: 80, targetPort: 80}
+  selector: {
+    kubetools/name: generic-app-with-annotations,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  type: NodePort

--- a/tests/configs/basic_app/k8s_services.yml
+++ b/tests/configs/basic_app/k8s_services.yml
@@ -17,7 +17,7 @@ kind: Service
 metadata:
   annotations: {
     app.kubernetes.io/managed-by: kubetools,
-    app.kubernetes.io/name: generic-app-with-annotations
+    imageregistry: https://hub.docker.com/
   }
   labels: {
     kubetools/name: generic-app-with-annotations,

--- a/tests/configs/basic_app/k8s_services.yml
+++ b/tests/configs/basic_app/k8s_services.yml
@@ -34,3 +34,29 @@ spec:
     kubetools/role: app
   }
   type: NodePort
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools
+  }
+  labels: {
+    app.kubernetes.io/name: generic-app-with-labels,
+    kubetools/name: generic-app-with-labels,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  name: generic-app-with-labels
+spec:
+  ports:
+  - {port: 80, targetPort: 80}
+  selector: {
+    app.kubernetes.io/name: generic-app-with-labels,
+    kubetools/name: generic-app-with-labels,
+    kubetools/project_name: generic-app,
+    kubetools/role: app
+  }
+  type: NodePort

--- a/tests/configs/basic_app/kubetools.yml
+++ b/tests/configs/basic_app/kubetools.yml
@@ -38,6 +38,17 @@ deployments:
           timeoutSeconds: 5
           httpGet:
             path: /ping
+  generic-app-with-labels:
+    labels:
+      app.kubernetes.io/name: generic-app-with-labels
+    containers:
+      webserver:
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        containerContext: generic-context
+        probes:
+          timeoutSeconds: 5
+          httpGet:
+            path: /ping
 
 
 cronjobs:
@@ -50,6 +61,14 @@ cronjobs:
   generic-cronjob-with-annotations:
     annotations:
       imageregistry: "https://hub.docker.com/"
+    schedule: "*/1 * * * *"
+    concurrency_policy: "Allow"
+    containers:
+      generic-container:
+        containerContext: generic-context
+  generic-cronjob-with-labels:
+    labels:
+      app.kubernetes.io/name: generic-cronjob-with-labels
     schedule: "*/1 * * * *"
     concurrency_policy: "Allow"
     containers:

--- a/tests/configs/basic_app/kubetools.yml
+++ b/tests/configs/basic_app/kubetools.yml
@@ -27,6 +27,17 @@ deployments:
           timeoutSeconds: 5
           httpGet:
             path: /ping
+  generic-app-with-annotations:
+    containers:
+      webserver:
+        command: [uwsgi, --ini, /etc/uwsgi.conf]
+        containerContext: generic-context
+        probes:
+          timeoutSeconds: 5
+          httpGet:
+            path: /ping
+        annotations:
+          app.kubernetes.io/name: "generic-app-with-annotations"
 
 
 cronjobs:
@@ -36,3 +47,11 @@ cronjobs:
     containers:
       generic-container:
         containerContext: generic-context
+  generic-cronjob-with-annotations:
+    schedule: "*/1 * * * *"
+    concurrency_policy: "Allow"
+    containers:
+      generic-container:
+        containerContext: generic-context
+        annotations:
+          app.kubernetes.io/name: "generic-cronjob-with-annotations"

--- a/tests/configs/basic_app/kubetools.yml
+++ b/tests/configs/basic_app/kubetools.yml
@@ -37,7 +37,7 @@ deployments:
           httpGet:
             path: /ping
         annotations:
-          app.kubernetes.io/name: "generic-app-with-annotations"
+          imageregistry: "https://hub.docker.com/"
 
 
 cronjobs:
@@ -54,4 +54,4 @@ cronjobs:
       generic-container:
         containerContext: generic-context
         annotations:
-          app.kubernetes.io/name: "generic-cronjob-with-annotations"
+          imageregistry: "https://hub.docker.com/"

--- a/tests/configs/basic_app/kubetools.yml
+++ b/tests/configs/basic_app/kubetools.yml
@@ -28,6 +28,8 @@ deployments:
           httpGet:
             path: /ping
   generic-app-with-annotations:
+    annotations:
+      imageregistry: "https://hub.docker.com/"
     containers:
       webserver:
         command: [uwsgi, --ini, /etc/uwsgi.conf]
@@ -36,8 +38,6 @@ deployments:
           timeoutSeconds: 5
           httpGet:
             path: /ping
-        annotations:
-          imageregistry: "https://hub.docker.com/"
 
 
 cronjobs:
@@ -48,10 +48,10 @@ cronjobs:
       generic-container:
         containerContext: generic-context
   generic-cronjob-with-annotations:
+    annotations:
+      imageregistry: "https://hub.docker.com/"
     schedule: "*/1 * * * *"
     concurrency_policy: "Allow"
     containers:
       generic-container:
         containerContext: generic-context
-        annotations:
-          imageregistry: "https://hub.docker.com/"

--- a/tests/configs/dependencies/k8s_deployments.yml
+++ b/tests/configs/dependencies/k8s_deployments.yml
@@ -53,3 +53,35 @@ spec:
         image: memcache:1.4.33
         imagePullPolicy: Always
         name: memcache-2
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    app.kubernetes.io/name: memcache-with-annotations
+  }
+  labels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
+    kubetools/role: dependency}
+  name: dependencies-memcache-with-annotations
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
+      kubetools/role: dependency}
+  template:
+    metadata:
+      labels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
+        kubetools/role: dependency}
+    spec:
+      containers:
+      - command: [memcached, -u, root, -I, 10m]
+        containerContext: memcache
+        env:
+        - {name: KUBE, value: 'true'}
+        image: memcache:1.4.33
+        imagePullPolicy: Always
+        name: memcache-with-annotations

--- a/tests/configs/dependencies/k8s_deployments.yml
+++ b/tests/configs/dependencies/k8s_deployments.yml
@@ -61,7 +61,7 @@ kind: Deployment
 metadata:
   annotations: {
     app.kubernetes.io/managed-by: kubetools,
-    app.kubernetes.io/name: memcache-with-annotations
+    imageregistry: https://hub.docker.com/
   }
   labels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
     kubetools/role: dependency}

--- a/tests/configs/dependencies/k8s_deployments.yml
+++ b/tests/configs/dependencies/k8s_deployments.yml
@@ -85,3 +85,44 @@ spec:
         image: memcache:1.4.33
         imagePullPolicy: Always
         name: memcache-with-annotations
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {
+    app.kubernetes.io/name: memcache-with-labels,
+    kubetools/name: dependencies-memcache-with-labels,
+    kubetools/project_name: dependencies,
+    kubetools/role: dependency
+  }
+  name: dependencies-memcache-with-labels
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels: {
+      app.kubernetes.io/name: memcache-with-labels,
+      kubetools/name: dependencies-memcache-with-labels,
+      kubetools/project_name: dependencies,
+      kubetools/role: dependency
+    }
+  template:
+    metadata:
+      labels: {
+        app.kubernetes.io/name: memcache-with-labels,
+        kubetools/name: dependencies-memcache-with-labels,
+        kubetools/project_name: dependencies,
+        kubetools/role: dependency
+      }
+    spec:
+      containers:
+      - command: [memcached, -u, root, -I, 10m]
+        containerContext: memcache
+        env:
+        - {name: KUBE, value: 'true'}
+        image: memcache:1.4.33
+        imagePullPolicy: Always
+        name: memcache-with-labels

--- a/tests/configs/dependencies/k8s_services.yml
+++ b/tests/configs/dependencies/k8s_services.yml
@@ -46,3 +46,27 @@ spec:
   selector: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
     kubetools/role: dependency}
   type: NodePort
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {app.kubernetes.io/managed-by: kubetools}
+  labels: {
+    app.kubernetes.io/name: memcache-with-labels,
+    kubetools/name: dependencies-memcache-with-labels,
+    kubetools/project_name: dependencies,
+    kubetools/role: dependency
+  }
+  name: dependencies-memcache-with-labels
+spec:
+  ports:
+  - {port: 11211, targetPort: 11211}
+  selector: {
+    app.kubernetes.io/name: memcache-with-labels,
+    kubetools/name: dependencies-memcache-with-labels,
+    kubetools/project_name: dependencies,
+    kubetools/role: dependency
+  }
+  type: NodePort

--- a/tests/configs/dependencies/k8s_services.yml
+++ b/tests/configs/dependencies/k8s_services.yml
@@ -35,7 +35,7 @@ kind: Service
 metadata:
   annotations: {
     app.kubernetes.io/managed-by: kubetools,
-    app.kubernetes.io/name: memcache-with-annotations
+    imageregistry: https://hub.docker.com/
   }
   labels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
     kubetools/role: dependency}

--- a/tests/configs/dependencies/k8s_services.yml
+++ b/tests/configs/dependencies/k8s_services.yml
@@ -27,3 +27,22 @@ spec:
   selector: {kubetools/name: dependencies-memcache-2, kubetools/project_name: dependencies,
     kubetools/role: dependency}
   type: NodePort
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {
+    app.kubernetes.io/managed-by: kubetools,
+    app.kubernetes.io/name: memcache-with-annotations
+  }
+  labels: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
+    kubetools/role: dependency}
+  name: dependencies-memcache-with-annotations
+spec:
+  ports:
+  - {port: 11211, targetPort: 11211}
+  selector: {kubetools/name: dependencies-memcache-with-annotations, kubetools/project_name: dependencies,
+    kubetools/role: dependency}
+  type: NodePort

--- a/tests/configs/dependencies/kubetools.yml
+++ b/tests/configs/dependencies/kubetools.yml
@@ -26,6 +26,12 @@ dependencies:
     containers:
       memcache-with-annotations:
         containerContext: memcache
+  memcache-with-labels:
+    labels:
+      app.kubernetes.io/name: memcache-with-labels
+    containers:
+      memcache-with-labels:
+        containerContext: memcache
 
   elasticsearch:
     conditions:

--- a/tests/configs/dependencies/kubetools.yml
+++ b/tests/configs/dependencies/kubetools.yml
@@ -25,7 +25,7 @@ dependencies:
       memcache-with-annotations:
         containerContext: memcache
         annotations:
-          app.kubernetes.io/name: "memcache-with-annotations"
+          imageregistry: https://hub.docker.com/
 
   elasticsearch:
     conditions:

--- a/tests/configs/dependencies/kubetools.yml
+++ b/tests/configs/dependencies/kubetools.yml
@@ -21,11 +21,11 @@ dependencies:
         containerContext: memcache
 
   memcache-with-annotations:
+    annotations:
+      imageregistry: https://hub.docker.com/
     containers:
       memcache-with-annotations:
         containerContext: memcache
-        annotations:
-          imageregistry: https://hub.docker.com/
 
   elasticsearch:
     conditions:

--- a/tests/configs/dependencies/kubetools.yml
+++ b/tests/configs/dependencies/kubetools.yml
@@ -20,6 +20,13 @@ dependencies:
       memcache-2:
         containerContext: memcache
 
+  memcache-with-annotations:
+    containers:
+      memcache-with-annotations:
+        containerContext: memcache
+        annotations:
+          app.kubernetes.io/name: "memcache-with-annotations"
+
   elasticsearch:
     conditions:
       dev: true


### PR DESCRIPTION
## Purpose of PR

---

I have tried on the following resources with and without `annotations`
```
name: telegraf-test

deployments:
  telegraf-test:
    annotations:
       app.kubernetes.io/name: "telegraf-test"
    containers:
      telegraf-test:
        image: test-image
        

dependencies:
  mariadb:
    annotations:
         app.kubernetes.io/name: "telegraf-test"
    containers:
      mariadb-container:
        image: test-images

cronjobs:
  my-cronjob:
    annotations:
       app.kubernetes.io/name: "telegraf-test"
    schedule: "*/1 * * * *"
    concurrency_policy: "Replace"
    containers:
      hello:
        image: test-images
        command: [/bin/sh, -c, date; echo Hello from the Kubernetes cluster]

```

## Parts of the app this will impact

## Todos

## Additional information

## Related links