### PR TITLE
Update Docker Compose integration to use v2 CLI and get container name

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-latest]
+        os: [ubuntu-22.04, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,11 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        exclude:
-          # Python 3.6 is not available in GitHub Actions Ubuntu 22.04
-          - os: ubuntu-latest
-            python-version: '3.6'
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+# v14.0.0
+- Support Docker compose v2
+- Drop Python 3.7 support
+
 # v13.14.2
 - Collect additional parameters provided to kubetools cronjob spec and attach to k8s cronjob spec
 

--- a/kubetools/__init__.py
+++ b/kubetools/__init__.py
@@ -1,3 +1,3 @@
-from pkg_resources import get_distribution
+from importlib import metadata
 
-__version__ = get_distribution('kubetools').version
+__version__ = metadata.version("kubetools")

--- a/kubetools/config.py
+++ b/kubetools/config.py
@@ -7,7 +7,7 @@ from os import getcwd, path
 
 import yaml
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from . import __version__
 from .exceptions import KubeConfigError

--- a/kubetools/dev/backends/docker_compose/config.py
+++ b/kubetools/dev/backends/docker_compose/config.py
@@ -248,9 +248,8 @@ def create_compose_config(kubetools_config):
     if dev_network:
         compose_config['networks'] = {
             'default': {
-                'external': {
-                    'name': 'dev',
-                },
+                'name': 'dev',
+                'external': True,
             },
         }
 

--- a/kubetools/dev/backends/docker_compose/docker_util.py
+++ b/kubetools/dev/backends/docker_compose/docker_util.py
@@ -1,5 +1,3 @@
-import sys
-
 from functools import lru_cache
 
 import docker
@@ -138,8 +136,8 @@ def get_containers_status(
         if not env:
             env = compose_project.replace(docker_name, '')
 
-        # Where the name is compose-name_container_N, get container
-        name = container.name.split('_')[1]
+        # Get the service name from the Docker Compose label (works with both v1 and v2)
+        name = container.labels['com.docker.compose.service']
 
         status = container.status == 'running'
         ports = []
@@ -204,8 +202,7 @@ def run_compose_process(kubetools_config, command_args, **kwargs):
     create_compose_config(kubetools_config)
 
     compose_command = [
-        # Use current interpreter to run the docker-compose module installed in the same venv
-        sys.executable, '-m', 'compose',
+        'docker', 'compose',
         # Force us to look at the current directory, not relative to the compose
         # filename (ie .kubetools/compose-name.yml).
         '--project-directory', '.',

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,6 @@ if __name__ == '__main__':
             # To support CronJob api versions 'batch/v1beta1' & 'batch/v1'
             'kubernetes>=21.7.0,<25.0.0',
             'tabulate<1',
-            # compose v2 has broken container naming
-            'docker-compose<2',
         ),
         extras_require={
             'dev': (

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ if __name__ == '__main__':
             'pyyaml>=3,<6',
             'requests>=2,<2.29.0',  # https://github.com/docker/docker-py/issues/3113
             'pyretry',
-            'setuptools',
             # To support CronJob api versions 'batch/v1beta1' & 'batch/v1'
             'kubernetes>=21.7.0,<25.0.0',
             'tabulate<1',


### PR DESCRIPTION
from labels

This pull request introduces several important updates in preparation for version 14.0.0, including support for Docker Compose v2, removal of Python 3.7 support, and modernization of some dependencies and internal APIs. The changes also update the GitHub Actions test matrix and streamline Docker Compose integration.

**Key changes:**

**Docker Compose v2 support and related improvements:**
* Updated Docker Compose integration to use the `docker compose` CLI (instead of the Python module or `docker-compose`), enabling support for Docker Compose v2. This includes changing how compose processes are run and how container service names are extracted, ensuring compatibility across Compose versions. [[1]](diffhunk://#diff-9e7acd433c2a68cab42ea6663574b6d9ea712c5a3a456cde473a501121d42aedL207-R205) [[2]](diffhunk://#diff-9e7acd433c2a68cab42ea6663574b6d9ea712c5a3a456cde473a501121d42aedL141-R140) [[3]](diffhunk://#diff-0ddc34c607283bbd8573fb06c612c0d74ad68ac252d3a427ea6ec2cbe86d6e53L251-R252)
* Removed the `docker-compose<2` dependency and related comments from `setup.py`, reflecting the move to Compose v2 and the CLI approach.

**Python version and dependency updates:**
* Dropped support for Python 3.7 and updated the GitHub Actions test matrix to test only supported Python versions (3.8+), and updated the tested Ubuntu versions. [[1]](diffhunk://#diff-c2e9f7c1bfaf65da79bbd29ed3ce389b2acc8b4099a257914a7292a66e6b9bc9L9-R10) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R8)

**Dependency and import modernization:**
* Replaced deprecated `pkg_resources` usage with `importlib.metadata` for version retrieval in `__init__.py`.
* Switched from `pkg_resources.parse_version` to `packaging.version.parse` for version parsing in `config.py`.

**Changelog:**
* Added a new section for v14.0.0 in `CHANGELOG.md` documenting Docker Compose v2 support and Python 3.7 deprecation.